### PR TITLE
Fixed MentoringManagerTests and expanded coverage.

### DIFF
--- a/src/MoreSpeakers.Managers.Tests/MoreSpeakers.Managers.Tests.csproj
+++ b/src/MoreSpeakers.Managers.Tests/MoreSpeakers.Managers.Tests.csproj
@@ -44,6 +44,7 @@
         </PackageReference>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.9.3" />
@@ -56,7 +57,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="Xunit"/>
+        <Using Include="Xunit" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Contributes to #88.

Replaced `Mock<ILogger>` with `FakeLogger` and introduced a dummy `TelemetryClient` for improved testability. Updated `CreateSut` to use these new components. Added error logging for failure scenarios in `MentoringManager` methods and verified them with new test cases.

Refactored test cases to use modern collection initializers and added the `Microsoft.Extensions.Diagnostics.Testing` package to support `FakeLogger`. Enhanced logging messages to include detailed context and adjusted telemetry event tracking for consistency.

Performed general cleanup and formatting improvements across `MentoringManager` and test files. No functional changes to existing delegation methods.