### PR TITLE
Fix #126: Update seed data to enable pagination verification

### DIFF
--- a/scripts/database/seed-data.sql
+++ b/scripts/database/seed-data.sql
@@ -100,3 +100,36 @@ INSERT INTO MoreSpeakers.dbo.UserExpertises (UserId, ExpertiseId, CreatedDate) V
 INSERT INTO MoreSpeakers.dbo.UserExpertises (UserId, ExpertiseId, CreatedDate) VALUES (N'3cae1cf9-c6a8-4b50-91e5-9030a678a0fa', 3, N'2025-11-09 14:32:09.7433333');
 INSERT INTO MoreSpeakers.dbo.UserExpertises (UserId, ExpertiseId, CreatedDate) VALUES (N'3cae1cf9-c6a8-4b50-91e5-9030a678a0fa', 33, N'2025-11-09 14:32:09.7433333');
 INSERT INTO MoreSpeakers.dbo.UserExpertises (UserId, ExpertiseId, CreatedDate) VALUES (N'3cae1cf9-c6a8-4b50-91e5-9030a678a0fa', 36, N'2025-11-09 14:32:09.7433333');
+
+-- GENERATE 35 USERS FOR PAGINATION TESTING
+INSERT INTO MoreSpeakers.dbo.AspNetUsers (
+    Id, UserName, NormalizedUserName, Email, NormalizedEmail,
+    EmailConfirmed, PasswordHash, SecurityStamp, ConcurrencyStamp,
+    PhoneNumber, PhoneNumberConfirmed, TwoFactorEnabled, LockoutEnabled, AccessFailedCount,
+    FirstName, LastName, Bio, SpeakerTypeId, Goals, CreatedDate, UpdatedDate, IsActive,
+    IsAvailableForMentoring, MaxMentees
+)
+SELECT TOP 35
+    NEWID(),
+    'speaker' + CAST(ROW_NUMBER() OVER (ORDER BY a.object_id) AS NVARCHAR(10)) + '@test.com',
+       'SPEAKER' + CAST(ROW_NUMBER() OVER (ORDER BY a.object_id) AS NVARCHAR(10)) + '@TEST.COM',
+       'speaker' + CAST(ROW_NUMBER() OVER (ORDER BY a.object_id) AS NVARCHAR(10)) + '@test.com',
+       'SPEAKER' + CAST(ROW_NUMBER() OVER (ORDER BY a.object_id) AS NVARCHAR(10)) + '@TEST.COM',
+       1,
+       'AQAAAAIAAYagAAAAEEIXrlcIOOnsJVbTQxiYwul61oWeKDu0tgtSjSafmw7Obixv0lqEKbN2cwRS5LHNAA==', -- Same hash as seeded users
+       NEWID(), NEWID(),
+       '1-555-555-' + RIGHT('0000' + CAST(ROW_NUMBER() OVER (ORDER BY a.object_id) AS NVARCHAR(4)), 4), -- Generates 1-555-555-0001 (14 chars)
+    1, 0, 1, 0,
+    'TestUser', -- FirstName (Length > 2)
+    'Speaker ' + CAST(ROW_NUMBER() OVER (ORDER BY a.object_id) AS NVARCHAR(10)), -- LastName (Length > 2 guaranteed)
+    'Generated bio for pagination testing. User ' + CAST(ROW_NUMBER() OVER (ORDER BY a.object_id) AS NVARCHAR(10)),
+    (ROW_NUMBER() OVER (ORDER BY a.object_id) % 2) + 1, -- Alternates between 1 (New) and 2 (Experienced)
+    'Testing goals',
+    GETUTCDATE(), GETUTCDATE(), 1, 1, 2
+FROM sys.all_columns a;
+
+-- Give them all C# expertise so they show up in default searches
+INSERT INTO MoreSpeakers.dbo.UserExpertises (UserId, ExpertiseId, CreatedDate)
+SELECT Id, 1, GETUTCDATE()
+FROM MoreSpeakers.dbo.AspNetUsers
+WHERE Email LIKE 'speaker%@test.com';


### PR DESCRIPTION
### Description
This PR updates the `seed-data.sql` script to include logic for generating 35 dummy users during database seeding.

### Motivation
Currently, the seed data only contains 3 users. The "Browse Speakers" page has a page size of 12, meaning pagination controls are never rendered in the default development environment. This makes it impossible to verify or test the pagination UI without manual database intervention.

### Changes
- Added `INSERT INTO` logic to generate 35 unique users based on system table rows.

### Verification Steps
1. Delete the existing development database volume (or drop the database).
2. Run the AppHost to re-seed the database.
3. Navigate to `/Speakers/Index`.
4. Scroll to the bottom to verify that page numbers (1, 2, 3) and "Next" buttons are now visible and functional.

Closes #126


<img width="1463" height="1119" alt="image" src="https://github.com/user-attachments/assets/607512ab-0bd2-41ee-8688-d84898458125" />
