### PR TITLE
Feature #159: Change Register URL to /Register

### DIFF
--- a/src/MoreSpeakers.Web/Areas/Identity/Pages/Account/Register.cshtml
+++ b/src/MoreSpeakers.Web/Areas/Identity/Pages/Account/Register.cshtml
@@ -1,4 +1,4 @@
-@page
+@page "/Register"
 @model MoreSpeakers.Web.Areas.Identity.Pages.Account.RegisterModel
 @{
     ViewData["Title"] = "Join MoreSpeakers.com";

--- a/src/MoreSpeakers.Web/Areas/Identity/Pages/Account/_RegisterStep1.cshtml
+++ b/src/MoreSpeakers.Web/Areas/Identity/Pages/Account/_RegisterStep1.cshtml
@@ -48,7 +48,7 @@
             </span>
             <input asp-for="Input.Email" class="form-control border-start-0" autocomplete="username"
                    placeholder="Enter your email"
-                   hx-post="/Identity/Account/Register?handler=ValidateEmail"
+                   hx-post="/Register?handler=ValidateEmail"
                    hx-trigger="blur, keyup changed delay:500ms"
                    hx-target="#email-validation-message"
                    hx-include="this"

--- a/src/MoreSpeakers.Web/Areas/Identity/Pages/Account/_RegisterStep3.cshtml
+++ b/src/MoreSpeakers.Web/Areas/Identity/Pages/Account/_RegisterStep3.cshtml
@@ -39,7 +39,7 @@
             <div class="input-group mb-2 custom-expertise-input" data-expertise-index="0">
                 <input type="text" name="Input.CustomExpertise" class="form-control custom-expertise-field"
                        placeholder="Enter a custom expertise area"
-                       hx-post="/Identity/Account/Register?handler=ValidateCustomExpertise"
+                       hx-post="/Register?handler=ValidateCustomExpertise"
                        hx-trigger="blur, keyup changed delay:500ms"
                        hx-target="next .custom-expertise-validation"
                        hx-include="this"
@@ -83,4 +83,3 @@
     <input type="hidden" asp-for="Input.HeadshotUrl" />
     <input type="hidden" asp-for="Input.SpeakerTypeId" />
 </div>
-

--- a/src/MoreSpeakers.Web/Areas/Identity/Pages/Account/_RegistrationContainer.cshtml
+++ b/src/MoreSpeakers.Web/Areas/Identity/Pages/Account/_RegistrationContainer.cshtml
@@ -73,7 +73,7 @@
         <div class="d-flex justify-content-between mt-4" id="navigationButtons">
             <button type="button" id="prevBtn" class="btn btn-outline-secondary"
                     style="display: @(currentStep == 1 ? "none" : "block");"
-                    hx-post="/Identity/Account/Register?handler=PreviousStep"
+                    hx-post="/Register?handler=PreviousStep"
                     hx-target="#registrationContainer"
                     hx-include="#registerForm"
                     hx-vals='{"step": "@currentStep"}'
@@ -84,7 +84,7 @@
             @if (currentStep < 4)
             {
                 <button type="button" id="nextBtn" class="btn btn-primary"
-                        hx-post="/Identity/Account/Register?handler=ValidateStep"
+                        hx-post="/Register?handler=ValidateStep"
                         hx-target="#registrationContainer"
                         hx-include="#registerForm"
                         hx-vals='{"step": "@currentStep"}'
@@ -95,7 +95,7 @@
             else
             {
                 <button type="button" id="submitBtn" class="btn btn-success"
-                        hx-post="/Identity/Account/Register?handler=Submit"
+                        hx-post="/Register?handler=Submit"
                         hx-target="#registrationContainer"
                         hx-include="#registerForm"
                         hx-swap="innerHTML">

--- a/src/MoreSpeakers.Web/wwwroot/js/site.js
+++ b/src/MoreSpeakers.Web/wwwroot/js/site.js
@@ -1,4 +1,4 @@
-﻿// MoreSpeakers.com JavaScript Utilities
+// MoreSpeakers.com JavaScript Utilities
 // This file contains minimal JavaScript to enhance the user experience
 
 // Initialize when DOM is loaded
@@ -431,7 +431,7 @@ function addCustomExpertise() {
     newInputGroup.innerHTML = `
         <input type="text" name="Input.CustomExpertise" class="form-control custom-expertise-field" 
                placeholder="Enter a custom expertise area"
-               hx-post="/Identity/Account/Register?handler=ValidateCustomExpertise"
+               hx-post="/Register?handler=ValidateCustomExpertise"
                hx-trigger="blur, keyup changed delay:500ms"
                hx-target="next .custom-expertise-validation"
                hx-include="this"


### PR DESCRIPTION
### Description
This PR updates the User Registration page routing to serve from the root `/Register` path instead of the default Identity area path (`/Identity/Account/Register`).

It includes updates to:
- The Razor Page route directive in `Register.cshtml`.
- Hardcoded HTMX path references in partial views (`_RegisterStep1`, `_RegisterStep3`, `_RegistrationContainer`).

### Motivation
To provide a cleaner, more user-friendly URL for sharing and marketing purposes, as requested in ticket #159.

### Verification
**Manual Verification Steps:**
1. Launched the application.
2. Navigated to `/Register` (verified page load).
3. Completed Step 1 (Account Info) and verified the Email Validation HTMX call fired correctly against the new URL.
4. Proceeded to Step 3 (Expertise) and verified the "Add Custom Expertise" JavaScript function correctly targets the `/Register` handler.

### Screenshots
<img width="1468" height="1338" alt="image" src="https://github.com/user-attachments/assets/125acd24-5ad4-4bdd-afc5-d5800a515330" />


### Link
Closes #159