### PR TITLE
Clean up unused dependencies and project files

### DIFF
--- a/src/MoreSpeakers.Data.Tests/MappingTests.cs
+++ b/src/MoreSpeakers.Data.Tests/MappingTests.cs
@@ -1,5 +1,4 @@
 ﻿using AutoMapper;
-using Xunit;
 
 namespace MoreSpeakers.Data.Tests;
 

--- a/src/MoreSpeakers.Data.Tests/MoreSpeakers.Data.Tests.csproj
+++ b/src/MoreSpeakers.Data.Tests/MoreSpeakers.Data.Tests.csproj
@@ -1,53 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <LangVersion>default</LangVersion>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <AssemblyName>MoreSpeakers.Data.Tests</AssemblyName>
-        <Company>Woodruff Solutions, LLC</Company>
-        <Authors>Chris Woodruff, Joseph Guadagno</Authors>
-        <Product>More Speakers - Data</Product>
-        <Description>The More Speakers Web application</Description>
-        <Copyright>Copyright ©2014-2025, Woodruff Solutions, LLC</Copyright>
-        <Title>More Speakers - Data Tests</Title>
-    </PropertyGroup>
 
-    <PropertyGroup>
-        <VersionMajor>1</VersionMajor>
-        <VersionMinor>3</VersionMinor>
-        <VersionBuild>1</VersionBuild>
-    </PropertyGroup>
-    <PropertyGroup>
-        <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionBuild)</VersionPrefix>
-    </PropertyGroup>
-    <PropertyGroup>
-        <VersionSuffix Condition=" '$(GITHUB_RUN_ID)' == '' ">local</VersionSuffix>
-        <VersionSuffix Condition=" '$(GITHUB_RUN_ID)' != '' And '$(Configuration)' == 'Debug'">$(GITHUB_RUN_ID)-preview</VersionSuffix>
-    </PropertyGroup>
-    <PropertyGroup>
-        <AssemblyVersion Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</AssemblyVersion>
-        <AssemblyVersion Condition=" '$(VersionSuffix)' == '' ">$(VersionPrefix)</AssemblyVersion>
-    </PropertyGroup>
-    <PropertyGroup>
-        <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
-        <FileVersion>$(VersionPrefix)</FileVersion>
-        <ProductVersion>$(VersionPrefix)($VersionSuffix)</ProductVersion>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="14.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="xunit.v3" Version="3.2.0" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\MoreSpeakers.Data\MoreSpeakers.Data.csproj" />
-    </ItemGroup>
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MoreSpeakers.Data.Tests</RootNamespace>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MoreSpeakers.Data\MoreSpeakers.Data.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/MoreSpeakers.Data/MappingProfiles/MoreSpeakersProfile.cs
+++ b/src/MoreSpeakers.Data/MappingProfiles/MoreSpeakersProfile.cs
@@ -1,5 +1,3 @@
-using System.Runtime.CompilerServices;
-
 using AutoMapper;
 
 namespace MoreSpeakers.Data.MappingProfiles;

--- a/src/MoreSpeakers.Data/MoreSpeakers.Data.csproj
+++ b/src/MoreSpeakers.Data/MoreSpeakers.Data.csproj
@@ -42,17 +42,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="14.0.0"/>
-        <PackageReference Include="AutoMapper.Collection.EntityFrameworkCore" Version="11.0.0" />
+        <PackageReference Include="AutoMapper" Version="14.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\MoreSpeakers.Domain\MoreSpeakers.Domain.csproj"/>
+        <ProjectReference Include="..\MoreSpeakers.Domain\MoreSpeakers.Domain.csproj" />
     </ItemGroup>
 </Project>

--- a/src/MoreSpeakers.Domain/Interfaces/IDataStorePrimaryKeyGuid.cs
+++ b/src/MoreSpeakers.Domain/Interfaces/IDataStorePrimaryKeyGuid.cs
@@ -1,5 +1,3 @@
-using MoreSpeakers.Domain.Models;
-
 namespace MoreSpeakers.Domain.Interfaces;
 
 public interface IDataStorePrimaryKeyGuid<T>: IDataStore<T> where T: class

--- a/src/MoreSpeakers.Domain/MoreSpeakers.Domain.csproj
+++ b/src/MoreSpeakers.Domain/MoreSpeakers.Domain.csproj
@@ -41,7 +41,6 @@
         <DocumentationFile>bin\Release\MoreSpeakers.Web.xml</DocumentationFile>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.0" />
       <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.0" />
     </ItemGroup>
 

--- a/src/MoreSpeakers.Managers.Tests/EmailSenderTests.cs
+++ b/src/MoreSpeakers.Managers.Tests/EmailSenderTests.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using MoreSpeakers.Domain.Interfaces;
 using MoreSpeakers.Domain.Models;
-using MoreSpeakers.Managers;
+
 using Azure.Storage.Queues;
 
 namespace MoreSpeakers.Managers.Tests;

--- a/src/MoreSpeakers.Managers.Tests/ExpertiseManagerTests.cs
+++ b/src/MoreSpeakers.Managers.Tests/ExpertiseManagerTests.cs
@@ -1,12 +1,9 @@
 using FluentAssertions;
 
-using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Logging;
 using Moq;
 using MoreSpeakers.Domain.Interfaces;
 using MoreSpeakers.Domain.Models;
-using MoreSpeakers.Managers;
 
 namespace MoreSpeakers.Managers.Tests;
 

--- a/src/MoreSpeakers.Managers.Tests/MentoringManagerTests.cs
+++ b/src/MoreSpeakers.Managers.Tests/MentoringManagerTests.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using MoreSpeakers.Domain.Interfaces;
 using MoreSpeakers.Domain.Models;
-using MoreSpeakers.Managers;
 
 namespace MoreSpeakers.Managers.Tests;
 

--- a/src/MoreSpeakers.Managers.Tests/MoreSpeakers.Managers.Tests.csproj
+++ b/src/MoreSpeakers.Managers.Tests/MoreSpeakers.Managers.Tests.csproj
@@ -43,8 +43,6 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.9.3" />
@@ -53,7 +51,6 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="8.8.0" />
-        <PackageReference Include="Bogus" Version="35.6.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MoreSpeakers.Managers.Tests/SocialMediaSiteManagerTests.cs
+++ b/src/MoreSpeakers.Managers.Tests/SocialMediaSiteManagerTests.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using MoreSpeakers.Domain.Interfaces;
 using MoreSpeakers.Domain.Models;
-using MoreSpeakers.Managers;
 
 namespace MoreSpeakers.Managers.Tests;
 

--- a/src/MoreSpeakers.Managers/MoreSpeakers.Managers.csproj
+++ b/src/MoreSpeakers.Managers/MoreSpeakers.Managers.csproj
@@ -48,7 +48,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Azure.Storage.Queues" Version="12.24.0" />
       <PackageReference Include="JosephGuadagno.AzureHelpers.Storage" Version="1.1.9" />
       <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />

--- a/src/MoreSpeakers.Web/Models/ViewModels/SpeakerResultsViewModel.cs
+++ b/src/MoreSpeakers.Web/Models/ViewModels/SpeakerResultsViewModel.cs
@@ -1,5 +1,3 @@
-using Microsoft.EntityFrameworkCore;
-
 namespace MoreSpeakers.Web.Models.ViewModels;
 
 public class SpeakerResultsViewModel

--- a/src/MoreSpeakers.Web/MoreSpeakers.Web.csproj
+++ b/src/MoreSpeakers.Web/MoreSpeakers.Web.csproj
@@ -49,9 +49,6 @@
         <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.0.0" />
         <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -61,15 +58,12 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />
-        <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
         <PackageReference Include="Serilog.Enrichers.AssemblyName" Version="2.0.0" />
         <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
         <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
         <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
-        <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.1.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-        <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MoreSpeakers.Web/Pages/Profile/Edit.cshtml.cs
+++ b/src/MoreSpeakers.Web/Pages/Profile/Edit.cshtml.cs
@@ -5,8 +5,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
-using System.Text.RegularExpressions;
-
 using MoreSpeakers.Domain.Interfaces;
 using MoreSpeakers.Domain.Models;
 using MoreSpeakers.Web.Models.ViewModels;

--- a/src/MoreSpeakers.Web/Program.cs
+++ b/src/MoreSpeakers.Web/Program.cs
@@ -1,8 +1,6 @@
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.WindowsServer;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 using MoreSpeakers.Domain.Interfaces;
 using MoreSpeakers.Domain.Models;


### PR DESCRIPTION
Favors transient packages when possible to reduce the effort required to support new NuGet package versions. Fixes #187

Removed unused `using` directives across multiple files to improve code clarity and maintainability. Simplified and reorganized project files by removing redundant `PropertyGroup` entries, unnecessary metadata, and unused `PackageReference` dependencies. Retained only essential dependencies in `.csproj` files. Streamlined code by eliminating unused namespaces and directives in various classes and test files.