### PR TITLE
chore: adding versioning to webapp workflow

### DIFF
--- a/.github/workflows/determine-next-release-version.yaml
+++ b/.github/workflows/determine-next-release-version.yaml
@@ -1,0 +1,109 @@
+# A reusable workflow that works with a repo Releases to determine what
+# the next version # should be.
+#
+# If the last Release version tag is not in the form vA.B.C, where
+# A, B, and C are numbers (1 or more digits) the workflow will report
+# an error.
+# The work flow has a single output with the version number (without
+# a leading 'v') and can be obtained within a calling workflow
+# with a statement similar to:
+# $${{ needs.determine_next_release_version.outputs.version }}
+---
+name: Determine next Release version number
+
+on:  # yamllint disable-line rule:truthy
+  workflow_call:
+    secrets:
+      token:
+        required: true
+    outputs:
+      version:
+        description: the version number that was determined
+        value: ${{ jobs.determine_next_release_version.outputs.version}}
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: false
+        default: 'none'
+        type: string
+
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: false
+        default: 'info'  # if manually run, you probably want at least info
+        type: choice
+        options: [none, info, warning, debug]
+
+env:
+  DEFAULT_MAJOR_VERSION: 1
+  DEFAULT_MINOR_VERSION: 4
+  DEFAULT_PATCH_VERSION: 1
+
+jobs:
+  determine_next_release_version:
+    runs-on: ubuntu-latest
+    name: Determine next Release version
+    outputs:
+      version: ${{ steps.determine_new_version.outputs.version }}
+    steps:
+      - name: Get latest release info
+        id: get_latest_release
+        uses: pozetroninc/github-action-get-latest-release@master
+        continue-on-error: true  # empty version checked later
+        with:
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          excludes: draft
+      - name: Report release info
+        if: ${{ inputs.logLevel == 'info' || inputs.logLevel == 'debug' }}
+        run: >
+          echo "Release: ${{ steps.get_latest_release.outputs.release }},
+          Id: ${{ steps.get_latest_release.outputs.id }},
+          '${{ steps.get_latest_release.outputs.description }}'"
+
+      - name: Determine scope of changes
+        id: determine_change_scope
+        run: |
+          echo "scope=patch" >> $GITHUB_OUTPUT
+
+      - name: Determine version
+        id: determine_new_version
+        shell: pwsh
+        run: |
+          if ([string]::IsNullOrWhiteSpace(`
+            "${{ steps.get_latest_release.outputs.release }}"))
+          {
+            $versionString = "v$($env:DEFAULT_MAJOR_VERSION)"+
+              ".$($env:DEFAULT_MINOR_VERSION).$($env:DEFAULT_PATCH_VERSION)"
+          }
+          else {
+            $versionString = "${{ steps.get_latest_release.outputs.release }}"
+          }
+
+          $scope = "${{ steps.determine_change_scope.outputs.scope }}"
+
+          if ($versionString -match '^v?(\d+)\.(\d+)\.(\d+)(?:-.+)?$') {
+              $major = [int]$matches[1]
+              $minor = [int]$matches[2]
+              $patch = [int]$matches[3]
+
+              switch ($scope) {
+                "major" { $major++; $minor = 0; $patch = 0 }
+                "minor" { $minor++; $patch = 0 }
+                "patch" { $patch++ }
+              }
+
+              $newVersion = "$major.$minor.$patch"
+              echo "version=$newVersion" >> $env:GITHUB_OUTPUT
+          }
+          else {
+              Write-Error "Version string not in expected format (vX.Y.Z)"
+          }
+      - name: Report next version
+        if: ${{ inputs.logLevel == 'info' || inputs.logLevel == 'debug' }}
+        run: >
+          echo "Determined that the next version is:
+          ${{steps.determine_new_version.outputs.version }}"

--- a/.github/workflows/publish-web-app.yml
+++ b/.github/workflows/publish-web-app.yml
@@ -2,6 +2,9 @@
 # More GitHub Actions for Azure: https://github.com/Azure/actions
 
 name: Build and deploy ASP.Net Core app to Azure Web App - web-more-speakers
+run-name: >
+  Webapp Deploy - '${{ github.event.head_commit.message }}',
+  from ${{ github.ref }} by @${{ github.actor }}
 
 on:
   push:
@@ -17,10 +20,19 @@ env:
   WORKING_DIRECTORY: ./src/MoreSpeakers.Web/
 
 jobs:
+  determine-version:
+    name: Determine next version number.
+    uses: ./.github/workflows/determine-next-release-version.yaml
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     runs-on: ubuntu-latest
+    needs: determine-version
     permissions:
-      contents: read #This is required for actions/checkout
+      contents: read  # This is required for actions/checkout
+    outputs:
+      artifact_name: ${{ steps.output-artifact-name.outputs.artifact_name }}
 
     steps:
       - uses: actions/checkout@v4
@@ -29,16 +41,25 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_CORE_VERSION }}
-      
+
       - name: Restore
         run: dotnet restore "${{ env.WORKING_DIRECTORY }}"
-      
+
       - name: Build
-        run: dotnet build "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-restore
-      
+        run: >
+          dotnet build "${{ env.WORKING_DIRECTORY }}"
+          --configuration ${{ env.CONFIGURATION }}
+          --no-restore
+          -p:Version=${{ needs.determine-version.outputs.version }}
+          -p:VersionPrefix=${{ needs.determine-version.outputs.version }}
+
       - name: Publish
-        run: dotnet publish "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-build --output "${{ env.AZURE_WEBAPP_PACKAGE_PATH }}"
-      
+        run: >
+          dotnet publish "${{ env.WORKING_DIRECTORY }}"
+          --configuration ${{ env.CONFIGURATION }}
+          --no-build
+          --output "${{ env.AZURE_WEBAPP_PACKAGE_PATH }}"
+
       - name: Publish Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -46,12 +67,68 @@ jobs:
           path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
           include-hidden-files: true
 
+      - name: Output artifact name
+        id: output-artifact-name
+        run: |
+          echo "artifact_name=webapp" >> $GITHUB_OUTPUT
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [build, determine-version]
+    permissions:
+      contents: write  # to be able to publish a GitHub release
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create Tag
+        id: create-tag
+        run: |
+          git tag v${{ needs.determine-version.outputs.version }}
+            echo "tag=\
+            v${{ needs.determine-version.outputs.version }}" \
+            >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        id: create-webapp-release
+        uses: actions/create-release@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.create-tag.outputs.tag }}
+          release_name: Release ${{ steps.create-tag.outputs.tag }}
+          body: |
+            Release created automatically by GitHub Actions.
+          draft: false
+
+      - name: download artifact for Release
+        id: download-artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: ${{ needs.build.outputs.artifact_name }}
+          path: ./Release
+
+      - name: create zip
+        run: |
+          (cd Release && zip -r ${{ needs.build.outputs.artifact_name }}.zip .)
+
+      - name: Upload a Release Asset
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-webapp-release.outputs.upload_url }}
+          asset_path: Release/${{ needs.build.outputs.artifact_name }}.zip
+          asset_name: ${{ needs.build.outputs.artifact_name }}.zip
+          asset_content_type: application/zip
+
   deploy:
     runs-on: ubuntu-latest
     needs: build
     permissions:
-      id-token: write #This is required for requesting the JWT
-      contents: read #This is required for actions/checkout
+      id-token: write  # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
 
     steps:
       - name: Download artifact from build job
@@ -59,7 +136,7 @@ jobs:
         with:
           name: webapp
           path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
-      
+
       - name: Login to Azure
         uses: azure/login@v2
         with:
@@ -75,4 +152,3 @@ jobs:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}
           package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
           slot-name: Production
-          


### PR DESCRIPTION
Versioning in the webapp workflow:
- getting the version of the last GitHub Release--defaulting to 1.4.1 (configurable) if no releases exist.
- incrementing the last version by patch (to 1.4.2, for example) until decision on how minor/major incrementing should be handled
- Include version in build command so latest version will display in webapp.
- Create a release with new version on successful build including built artifacts.

Next steps to consider:
- how to deal with a minor or major bump
- Does versioning need to be applied to the function app, and should it match the webapp?
- Cleaning up webapp csproj as most of the version sections are not needed.