### PR TITLE
Added Conventional Commit support to workflow versioning #185

### DIFF
--- a/.github/workflows/determine-next-release-version.yaml
+++ b/.github/workflows/determine-next-release-version.yaml
@@ -64,10 +64,29 @@ jobs:
           Id: ${{ steps.get_latest_release.outputs.id }},
           '${{ steps.get_latest_release.outputs.description }}'"
 
+      # Determine the scope of the changes based on commit messages,
+      # looking for comments following Conventional Commits
       - name: Determine scope of changes
         id: determine_change_scope
         run: |
-          echo "scope=patch" >> $GITHUB_OUTPUT
+          commits=$(git log \
+          ${{ steps.get_latest_release.outputs.release }}..HEAD \
+          --pretty=format:"%s")
+          echo "$commits" > commits.txt
+
+          if ${{ inputs.logLevel == 'info' || inputs.logLevel == 'debug' }}; then
+            cat commits.txt
+          fi
+          scope="patch"
+          if grep -q "BREAKING CHANGE" commits.txt; then
+            scope="major"
+          elif grep -q "^feat:" commits.txt; then
+            scope="minor"
+          elif grep -q "^fix:" commits.txt; then
+            scope="patch"
+          fi
+
+          echo "scope=$scope" >> $GITHUB_OUTPUT
 
       - name: Determine version
         id: determine_new_version


### PR DESCRIPTION
This enhances the versioning in the webapp workflow to support [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) so that the minor version will be incremented (and the patch version reset to 0) if a commit message starts with "feat:" and will increment the major version (and reset the minor version to 0 and patch version to 0) if a commit message includes "BREAKING CHANGE".

This provides some control over how commits will affect the version.

This doesn't enforce use of Conventional Commits, so at worst case only the patch version will be incremented on a merge/commit into main.