### PR TITLE
Refactor admin role strings to use constants

### DIFF
--- a/docs/new-admin-functionality-implementation-plan.md
+++ b/docs/new-admin-functionality-implementation-plan.md
@@ -14,7 +14,7 @@ This makes it straightforward to introduce an Admin area, use the `Managers` as 
 ## High‑level Admin Plan (what to add)
 
 1) Admin Area & Authorization
-- Create an Admin area: `MoreSpeakers.Web/Areas/Admin` with MVC controllers or Razor Pages, protected by `[Authorize(Roles = "Administrator")]`.
+- Create an Admin area: `MoreSpeakers.Web/Areas/Admin` with MVC controllers or Razor Pages, protected by `[Authorize(Roles = Domain.Constants.UserRoles.Administrator)]`.
 - Define policies to support least privilege beyond the coarse `Administrator` role (e.g., `Policy.ManageUsers`, `Policy.ManageCatalog`, `Policy.ViewReports`). Use `[Authorize(Policy = "ManageUsers")]` for sensitive actions.
 - Add an Admin layout and navigation shell with links to Users, Social Sites, Expertise, Moderation, Settings, Reports.
 
@@ -83,7 +83,7 @@ This makes it straightforward to introduce an Admin area, use the `Managers` as 
 
 8) Security & Compliance
 - Authorization:
-    - Keep `[Authorize(Roles = "Administrator")]` for the area and apply granular policies to controller actions.
+    - Keep `[Authorize(Roles = Domain.Constants.UserRoles.Administrator)]` for the area and apply granular policies to controller actions.
     - Consider a secondary role like `Moderator` for content review without user management powers.
 - Input safety: server-side validation across all admin forms; anti-forgery tokens; strict model binding.
 - Audit logs:
@@ -401,7 +401,7 @@ This migration does not require changing Razor Pages folder conventions or page 
 Each phase will be a new issue.
 
 1. Foundation
-    - Admin area scaffold, nav shell, `[Authorize(Roles = "Administrator")]` and granular policies
+    - Admin area scaffold, nav shell, `[Authorize(Roles = Domain.Constants.UserRoles.Administrator)]` and granular policies
     - Admin landing dashboard with health and quick links
 2. Catalog Management
     - Social media sites admin CRUD with validation and previews

--- a/src/MoreSpeakers.Domain/Constants/UserRoles.cs
+++ b/src/MoreSpeakers.Domain/Constants/UserRoles.cs
@@ -1,0 +1,36 @@
+namespace MoreSpeakers.Domain.Constants;
+
+/// <summary>
+/// Contains the names of the roles used by the application.
+/// </summary>
+public static class UserRoles
+{
+    /// <summary>
+    /// A new speaker role.
+    /// </summary>
+    public const string NewSpeaker = "NewSpeaker";
+    /// <summary>
+    /// A reporter role.
+    /// </summary>
+    public const string Reporter = "Reporter";
+    /// <summary>
+    /// The administrator role.
+    /// </summary>
+    public const string Administrator = "Administrator";
+    /// <summary>
+    /// The user manager role.
+    /// </summary>
+    public const string UserManager = "UserManager";
+    /// <summary>
+    /// The catalog manager role.
+    /// </summary>
+    public const string CatalogManager = "CatalogManager";
+    /// <summary>
+    /// The experienced speaker role.
+    /// </summary>
+    public const string ExperiencedSpeaker = "ExperiencedSpeaker";
+    /// <summary>
+    /// The moderator role.
+    /// </summary>
+    public const string Moderator = "Moderator";
+}

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Categories/Create.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Categories/Create.cshtml.cs
@@ -7,7 +7,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace MoreSpeakers.Web.Areas.Admin.Pages.Expertises.Categories;
 
-[Authorize(Roles = "Administrator")]
+[Authorize(Roles = Domain.Constants.UserRoles.Administrator)]
 public class CreateModel(IExpertiseManager expertiseManager, ISectorManager sectorManager, ILogger<CreateModel> logger) : PageModel
 {
     private readonly IExpertiseManager _expertiseManager = expertiseManager;

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Categories/Details.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Categories/Details.cshtml.cs
@@ -6,7 +6,7 @@ using MoreSpeakers.Domain.Models;
 
 namespace MoreSpeakers.Web.Areas.Admin.Pages.Expertises.Categories;
 
-[Authorize(Roles = "Administrator")]
+[Authorize(Roles = Domain.Constants.UserRoles.Administrator)]
 public class DetailsModel(IExpertiseManager expertiseManager, ISectorManager sectorManager) : PageModel
 {
     private readonly IExpertiseManager _expertiseManager = expertiseManager;

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Categories/Edit.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Categories/Edit.cshtml.cs
@@ -7,7 +7,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace MoreSpeakers.Web.Areas.Admin.Pages.Expertises.Categories;
 
-[Authorize(Roles = "Administrator")]
+[Authorize(Roles = Domain.Constants.UserRoles.Administrator)]
 public class EditModel(IExpertiseManager expertiseManager, ISectorManager sectorManager, ILogger<EditModel> logger) : PageModel
 {
     private readonly IExpertiseManager _expertiseManager = expertiseManager;

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Categories/Index.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Categories/Index.cshtml.cs
@@ -7,7 +7,7 @@ using MoreSpeakers.Domain.Models.AdminUsers;
 
 namespace MoreSpeakers.Web.Areas.Admin.Pages.Expertises.Categories;
 
-[Authorize(Roles = "Administrator")]
+[Authorize(Roles = Domain.Constants.UserRoles.Administrator)]
 public class IndexModel(IExpertiseManager expertiseManager, ILogger<IndexModel> logger) : PageModel
 {
     private readonly IExpertiseManager _expertiseManager = expertiseManager;

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Expertises/Create.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Expertises/Create.cshtml.cs
@@ -8,7 +8,7 @@ using MoreSpeakers.Web.Models.ViewModels;
 
 namespace MoreSpeakers.Web.Areas.Admin.Pages.Expertises.Expertises;
 
-[Authorize(Roles = "Administrator")]
+[Authorize(Roles = Domain.Constants.UserRoles.Administrator)]
 public class CreateModel(IExpertiseManager expertiseManager, ISectorManager sectorManager, ILogger<CreateModel> logger) : PageModel
 {
     private readonly IExpertiseManager _expertiseManager = expertiseManager;

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Expertises/Details.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Expertises/Details.cshtml.cs
@@ -6,7 +6,7 @@ using MoreSpeakers.Domain.Models;
 
 namespace MoreSpeakers.Web.Areas.Admin.Pages.Expertises.Expertises;
 
-[Authorize(Roles = "Administrator")]
+[Authorize(Roles = Domain.Constants.UserRoles.Administrator)]
 public class DetailsModel(IExpertiseManager expertiseManager, ISectorManager sectorManager) : PageModel
 {
     private readonly IExpertiseManager _expertiseManager = expertiseManager;

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Expertises/Edit.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Expertises/Edit.cshtml.cs
@@ -9,7 +9,7 @@ using MoreSpeakers.Web.Models.ViewModels;
 
 namespace MoreSpeakers.Web.Areas.Admin.Pages.Expertises.Expertises;
 
-[Authorize(Roles = "Administrator")]
+[Authorize(Roles = Domain.Constants.UserRoles.Administrator)]
 public class EditModel(IExpertiseManager expertiseManager, ISectorManager sectorManager, ILogger<EditModel> logger) : PageModel
 {
     private readonly IExpertiseManager _expertiseManager = expertiseManager;

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Expertises/Index.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Expertises/Index.cshtml.cs
@@ -7,7 +7,7 @@ using MoreSpeakers.Domain.Models.AdminUsers;
 
 namespace MoreSpeakers.Web.Areas.Admin.Pages.Expertises.Expertises;
 
-[Authorize(Roles = "Administrator")]
+[Authorize(Roles = Domain.Constants.UserRoles.Administrator)]
 public class IndexModel(IExpertiseManager expertiseManager, ILogger<IndexModel> logger) : PageModel
 {
     private readonly IExpertiseManager _expertiseManager = expertiseManager;

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Sectors/Create.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Sectors/Create.cshtml.cs
@@ -7,7 +7,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace MoreSpeakers.Web.Areas.Admin.Pages.Expertises.Sectors;
 
-[Authorize(Roles = "Administrator")]
+[Authorize(Roles = Domain.Constants.UserRoles.Administrator)]
 public class CreateModel(ISectorManager manager, ILogger<CreateModel> logger) : PageModel
 {
     private readonly ISectorManager _manager = manager;

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Sectors/Details.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Sectors/Details.cshtml.cs
@@ -6,7 +6,7 @@ using MoreSpeakers.Domain.Models;
 
 namespace MoreSpeakers.Web.Areas.Admin.Pages.Expertises.Sectors;
 
-[Authorize(Roles = "Administrator")]
+[Authorize(Roles = Domain.Constants.UserRoles.Administrator)]
 public class DetailsModel(ISectorManager sectorManager) : PageModel
 {
     private readonly ISectorManager _sectorManager = sectorManager;

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Sectors/Edit.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Sectors/Edit.cshtml.cs
@@ -7,7 +7,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace MoreSpeakers.Web.Areas.Admin.Pages.Expertises.Sectors;
 
-[Authorize(Roles = "Administrator")]
+[Authorize(Roles = Domain.Constants.UserRoles.Administrator)]
 public class EditModel(ISectorManager manager, ILogger<EditModel> logger) : PageModel
 {
     private readonly ISectorManager _manager = manager;

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Sectors/Index.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Expertises/Sectors/Index.cshtml.cs
@@ -7,7 +7,7 @@ using MoreSpeakers.Domain.Models.AdminUsers;
 
 namespace MoreSpeakers.Web.Areas.Admin.Pages.Expertises.Sectors;
 
-[Authorize(Roles = "Administrator")]
+[Authorize(Roles = Domain.Constants.UserRoles.Administrator)]
 public class IndexModel(ISectorManager manager, ILogger<IndexModel> logger) : PageModel
 {
     private readonly ISectorManager _manager = manager;

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Users/Details.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Users/Details.cshtml.cs
@@ -6,7 +6,7 @@ using MoreSpeakers.Domain.Models;
 
 namespace MoreSpeakers.Web.Areas.Admin.Pages.Users;
 
-[Authorize(Roles = "Administrator")]
+[Authorize(Roles = Domain.Constants.UserRoles.Administrator)]
 public class DetailsModel : PageModel
 {
     private readonly IUserManager _userManager;

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Users/Index.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Users/Index.cshtml.cs
@@ -7,7 +7,7 @@ using MoreSpeakers.Domain.Models.AdminUsers;
 
 namespace MoreSpeakers.Web.Areas.Admin.Pages.Users;
 
-[Authorize(Roles = "Administrator")]
+[Authorize(Roles = Domain.Constants.UserRoles.Administrator)]
 public class IndexModel(IUserManager userManager, ILogger<IndexModel> logger) : PageModel
 {
     private readonly IUserManager _userManager = userManager;


### PR DESCRIPTION
Replaced hardcoded occurrences of the "Administrator" role with `Domain.Constants.UserRoles.Administrator` to enhance code maintainability and consistency.

Refs: #292