### PR TITLE
Add OpenGraph metadata to profile pages

### DIFF
--- a/src/MoreSpeakers.Web.Tests/Services/OpenGraphServiceTests.cs
+++ b/src/MoreSpeakers.Web.Tests/Services/OpenGraphServiceTests.cs
@@ -1,0 +1,82 @@
+using FluentAssertions;
+using MoreSpeakers.Domain.Models;
+using MoreSpeakers.Web.Services;
+
+namespace MoreSpeakers.Web.Tests.Services;
+
+public class OpenGraphServiceTests
+{
+    private readonly OpenGraphService _service;
+
+    public OpenGraphServiceTests()
+    {
+        _service = new OpenGraphService();
+    }
+
+    [Fact]
+    public void GenerateUserMetadata_ShouldReturnCorrectMetadata_WhenUserHasAllFields()
+    {
+        // Arrange
+        var user = new User
+        {
+            FirstName = "John",
+            LastName = "Doe",
+            Bio = "Experienced speaker with a passion for C#.",
+            HeadshotUrl = "https://example.com/headshot.jpg"
+        };
+        var profileUrl = "https://morespeakers.com/speakers/john-doe";
+
+        // Act
+        var result = _service.GenerateUserMetadata(user, profileUrl);
+
+        // Assert
+        result["og:title"].Should().Be("John Doe's MoreSpeakers.com Profile");
+        result["og:type"].Should().Be("profile");
+        result["og:url"].Should().Be(profileUrl);
+        result["og:description"].Should().Be(user.Bio);
+        result["og:profile:first_name"].Should().Be("John");
+        result["og:profile:last_name"].Should().Be("Doe");
+        result["og:image"].Should().Be("https://example.com/headshot.jpg");
+    }
+
+    [Fact]
+    public void GenerateUserMetadata_ShouldNotIncludeImage_WhenHeadshotUrlIsEmpty()
+    {
+        // Arrange
+        var user = new User
+        {
+            FirstName = "Jane",
+            LastName = "Smith",
+            Bio = "New speaker.",
+            HeadshotUrl = null
+        };
+        var profileUrl = "https://morespeakers.com/speakers/jane-smith";
+
+        // Act
+        var result = _service.GenerateUserMetadata(user, profileUrl);
+
+        // Assert
+        result.Should().NotContainKey("og:image");
+    }
+
+    [Fact]
+    public void GenerateUserMetadata_ShouldTruncateDescription_WhenBioIsTooLong()
+    {
+        // Arrange
+        var longBio = new string('a', 400);
+        var user = new User
+        {
+            FirstName = "Alice",
+            LastName = "Wonderland",
+            Bio = longBio
+        };
+        var profileUrl = "https://morespeakers.com/speakers/alice-wonderland";
+
+        // Act
+        var result = _service.GenerateUserMetadata(user, profileUrl);
+
+        // Assert
+        result["og:description"].Should().HaveLength(303); // 300 + "..."
+        result["og:description"].Should().EndWith("...");
+    }
+}

--- a/src/MoreSpeakers.Web/Models/Constants.cs
+++ b/src/MoreSpeakers.Web/Models/Constants.cs
@@ -1,0 +1,9 @@
+namespace MoreSpeakers.Web.Models;
+
+public static class Constants
+{
+    public static class ViewBagTags
+    {
+        public const string OpenGraph = "OpenGraph";
+    }
+}

--- a/src/MoreSpeakers.Web/Pages/Profile/Index.cshtml.cs
+++ b/src/MoreSpeakers.Web/Pages/Profile/Index.cshtml.cs
@@ -3,10 +3,12 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 using MoreSpeakers.Domain.Interfaces;
 using MoreSpeakers.Domain.Models;
+using MoreSpeakers.Web.Models;
+using MoreSpeakers.Web.Services;
 
 namespace MoreSpeakers.Web.Pages.Profile;
 
-public class IndexModel(IUserManager userManager, ILogger<IndexModel> logger) : PageModel
+public class IndexModel(IUserManager userManager, IOpenGraphService openGraphService, LinkGenerator linkGenerator, ILogger<IndexModel> logger) : PageModel
 {
 
     public User UserProfile { get; set; } = null!;
@@ -77,6 +79,10 @@ public class IndexModel(IUserManager userManager, ILogger<IndexModel> logger) : 
             return RedirectToPage("/Profile/LoadingProblem",
                 new { UserId = identityUser?.Id ?? Guid.Empty });
         }
+
+        var profileUrl = linkGenerator.GetUriByPage(HttpContext, "/Profile/Index", null, new { Id = UserProfile.Id }) ??
+                         "https://www.morespeakers.com/";
+        ViewData[Constants.ViewBagTags.OpenGraph] = openGraphService.GenerateUserMetadata(UserProfile, profileUrl);
 
         return Page();
     }

--- a/src/MoreSpeakers.Web/Pages/Shared/_Layout.cshtml
+++ b/src/MoreSpeakers.Web/Pages/Shared/_Layout.cshtml
@@ -1,4 +1,5 @@
-﻿@using MoreSpeakers.Domain.Interfaces
+﻿@using Microsoft.EntityFrameworkCore.Metadata.Internal
+@using MoreSpeakers.Domain.Interfaces
 @inject ISettings Settings
 <!DOCTYPE html>
 <html lang="en" data-bs-theme="light">
@@ -7,6 +8,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="theme-color" content="#fd7e14"/>
     <title>@ViewData["Title"] - MoreSpeakers.com</title>
+    @if (ViewData[Models.Constants.ViewBagTags.OpenGraph] != null)
+    {
+        @await Html.PartialAsync("_OpenGraph", ViewData[Constants.ViewBagTags.OpenGraph])
+    }
     <link rel="apple-touch-icon" sizes="57x57" href="/images/favicons/apple-icon-57x57.png">
     <link rel="apple-touch-icon" sizes="60x60" href="/images/favicons/apple-icon-60x60.png">
     <link rel="apple-touch-icon" sizes="72x72" href="/images/favicons/apple-icon-72x72.png">

--- a/src/MoreSpeakers.Web/Pages/Shared/_OpenGraph.cshtml
+++ b/src/MoreSpeakers.Web/Pages/Shared/_OpenGraph.cshtml
@@ -1,0 +1,5 @@
+@model Dictionary<string, string>
+@foreach (var key in @Model.Keys)
+{
+    <meta property="@key" content="@Model[key]" />
+}

--- a/src/MoreSpeakers.Web/Program.cs
+++ b/src/MoreSpeakers.Web/Program.cs
@@ -179,6 +179,7 @@ builder.Services.AddScoped<IEmailSender, EmailSender>();
 builder.Services.AddScoped<Microsoft.AspNetCore.Identity.UI.Services.IEmailSender, EmailSender>();
 builder.Services.AddScoped<ITemplatedEmailSender, TemplatedEmailSender>();
 builder.Services.AddScoped<IRazorPartialToStringRenderer, RazorPartialToStringRenderer>();
+builder.Services.AddScoped<IOpenGraphService, OpenGraphService>();
 
 // Register GitHub Service and Add in-memory caching (required by GitHubService constructor)
 builder.Services.AddMemoryCache();

--- a/src/MoreSpeakers.Web/Services/IOpenGraphService.cs
+++ b/src/MoreSpeakers.Web/Services/IOpenGraphService.cs
@@ -1,0 +1,8 @@
+using MoreSpeakers.Domain.Models;
+
+namespace MoreSpeakers.Web.Services;
+
+public interface IOpenGraphService
+{
+    Dictionary<string, string> GenerateUserMetadata(User user, string profileUrl);
+}

--- a/src/MoreSpeakers.Web/Services/OpenGraphService.cs
+++ b/src/MoreSpeakers.Web/Services/OpenGraphService.cs
@@ -1,0 +1,32 @@
+using MoreSpeakers.Domain.Models;
+
+namespace MoreSpeakers.Web.Services;
+
+public class OpenGraphService : IOpenGraphService
+{
+    public Dictionary<string, string> GenerateUserMetadata(User user, string profileUrl)
+    {
+        var metadata = new Dictionary<string, string>
+        {
+            { "og:title", user.FullName + "'s MoreSpeakers.com Profile"},
+            { "og:type", "profile" },
+            { "og:url", profileUrl },
+            { "og:description", Truncate(user.Bio, 300) },
+            { "og:profile:first_name", user.FirstName },
+            { "og:profile:last_name", user.LastName }
+        };
+
+        if (!string.IsNullOrWhiteSpace(user.HeadshotUrl))
+        {
+            metadata.Add("og:image", user.HeadshotUrl);
+        }
+
+        return metadata;
+    }
+
+    private static string Truncate(string value, int maxLength)
+    {
+        if (string.IsNullOrEmpty(value)) return value;
+        return value.Length <= maxLength ? value : value.Substring(0, maxLength).TrimEnd() + "...";
+    }
+}


### PR DESCRIPTION
### Description

This pull request integrates OpenGraph metadata into user profile pages, enhancing social media link previews. Key changes include:

- Implemented `OpenGraphService` to generate OpenGraph metadata.
- Updated the Profile page to include metadata in `ViewData` for rendering.
- Added `_OpenGraph.cshtml` partial for meta tag inclusion in `_Layout`.
- Registered `IOpenGraphService` in the application dependency injection container.
- Introduced unit tests to validate `OpenGraphService` functionality. 

### Checklist

- [X] Tests have been added or updated to verify the changes.

Partially implements #157. Need to add the custom MoreSpeakers image to the profile link