### PR TITLE
Fix casing in MoreSpeakers.Functions project references

### DIFF
--- a/.github/workflows/publish-function-app.yml
+++ b/.github/workflows/publish-function-app.yml
@@ -14,7 +14,7 @@ env:
   AZURE_FUNCTIONAPP_PACKAGE_PATH: ./published
   CONFIGURATION: Release
   DOTNET_CORE_VERSION: 10.0.x
-  WORKING_DIRECTORY: ./src/Morespeakers.Functions/
+  WORKING_DIRECTORY: ./src/MoreSpeakers.Functions/
 
 jobs:
   build:
@@ -73,4 +73,3 @@ jobs:
           app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
           package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
           slot-name: Production
-    

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ MoreSpeakers/
 │   ├── MoreSpeakers.AppHost/         # .NET Aspire orchestration
 │   ├── MoreSpeakers.ServiceDefaults/ # .NET Aspire service defaults
 │   ├── MoreSpeakers.Domain/          # Domain models and abstractions
-│   ├── Morespeakers.Functions/       # Azure Functions (e.g., email notifications)
+│   ├── MoreSpeakers.Functions/       # Azure Functions (e.g., email notifications)
 │   ├── MoreSpeakers.Managers/        # Application services/managers/business logic
 │   ├── MoreSpeakers.Tests/           # Automated tests
 │   └── MoreSpeakers.Web/             # Main web application

--- a/docs/developer-startup.md
+++ b/docs/developer-startup.md
@@ -35,7 +35,7 @@ dotnet tool install -g Microsoft.Web.LibraryManager.Cli
 After installing Library Manager, or if you already have it, open up a terminal/command prompt and navigate to the project directory.
 
 ```bash
-cd /src/Morespeakers.Web
+cd /src/MoreSpeakers.Web
 libman restore
 ```
 

--- a/src/MoreSpeakers.AppHost/AppHost.cs
+++ b/src/MoreSpeakers.AppHost/AppHost.cs
@@ -38,7 +38,7 @@ var db = sql.AddDatabase("MoreSpeakers")
     .WithCreationScript(sqlText);
 
 // Add the Azure Functions
-builder.AddAzureFunctionsProject<Morespeakers_Functions>("functions")
+builder.AddAzureFunctionsProject<MoreSpeakers_Functions>("functions")
     .WithRoleAssignments(storage,
         // Storage Account Contributor and Storage Blob Data Owner roles are required by the Azure Functions host
         StorageBuiltInRole.StorageAccountContributor, StorageBuiltInRole.StorageBlobDataOwner,

--- a/src/MoreSpeakers.AppHost/MoreSpeakers.AppHost.csproj
+++ b/src/MoreSpeakers.AppHost/MoreSpeakers.AppHost.csproj
@@ -51,7 +51,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Morespeakers.Functions\Morespeakers.Functions.csproj" />
+        <ProjectReference Include="..\MoreSpeakers.Functions\MoreSpeakers.Functions.csproj" />
         <ProjectReference Include="..\MoreSpeakers.Web\MoreSpeakers.Web.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
- Corrected the casing of `MoreSpeakers.Functions` project references in multiple files:
  - `MoreSpeakers.AppHost.csproj`
  - `AppHost.cs`
  - `README.md`
  - `publish-function-app.yml` in GitHub Actions workflow
  - `developer-startup.md`  
- This fixes issues affecting function app deployments.

Refs #fix-function-deployment