### PR TITLE
Enhance email template management and accessibility

### DIFF
--- a/scripts/database/2026-01-18_add_email_templates.sql
+++ b/scripts/database/2026-01-18_add_email_templates.sql
@@ -1,16 +1,17 @@
-
 CREATE TABLE [dbo].[EmailTemplates](
-    Location [nvarchar](150) not null primary key,
+    Id INT IDENTITY(1,1) NOT NULL CONSTRAINT PK_EmailTemplates PRIMARY KEY,
+    Location [nvarchar](150) not null unique,
     Content [nvarchar](max) not null,
     CreatedDate datetime2 default getutcdate() not null,
     IsActive [bit] not null default 1,
     LastModified [datetime2] default getutcdate() not null,
-    LastRequested [datetime2] NULL,
-);
+    LastRequested [datetime2] NULL)
+GO
 
+SET IDENTITY_INSERT MoreSpeakers.dbo.EmailTemplates ON;
 INSERT INTO [dbo].[EmailTemplates]
-    ([Location], [Content])
-VALUES (
+    (Id, Location, Content)
+VALUES (1,
         '/Pages/Shared/_EmailLayout.cshtml',
         N'<!DOCTYPE html>
         <html lang="en">
@@ -61,8 +62,8 @@ VALUES (
        );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+    (Id, Location, Content)
+VALUES (2,
            '/EmailTemplates/ConfirmUserEmail.cshtml',
            N'@model MoreSpeakers.Domain.Models.UserConfirmationEmail
 
@@ -81,8 +82,8 @@ In order to take the next step in your journey, please confirm your email addres
        );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+    (Id, Location, Content)
+VALUES (3,
            '/EmailTemplates/MentorshipRequestAcceptedFromMentee.cshtml',
            '@model MoreSpeakers.Domain.Models.Mentorship
 
@@ -102,8 +103,8 @@ VALUES (
        );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+    (Id, Location, Content)
+VALUES (4,
            '/EmailTemplates/MentorshipRequestAcceptedToMentor.cshtml',
            '@model MoreSpeakers.Domain.Models.Mentorship
 
@@ -128,8 +129,8 @@ VALUES (
        );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+    (Id, Location, Content)
+VALUES (5,
            '/EmailTemplates/MentorshipRequestCancelledFromMentee.cshtml',
            '@model MoreSpeakers.Domain.Models.Mentorship
 
@@ -145,8 +146,8 @@ VALUES (
        );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+    (Id, Location, Content)
+VALUES (6,
            '/EmailTemplates/MentorshipRequestCancelledToMentor.cshtml',
            '@model MoreSpeakers.Domain.Models.Mentorship
 
@@ -162,8 +163,8 @@ VALUES (
        );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+    (Id, Location, Content)
+VALUES (7,
            '/EmailTemplates/MentorshipRequestDeclinedFromMentee.cshtml',
            N'@model MoreSpeakers.Domain.Models.Mentorship
 
@@ -181,8 +182,8 @@ VALUES (
        );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+    (Id, Location, Content)
+VALUES (8,
            '/EmailTemplates/MentorshipRequestDeclinedToMentor.cshtml',
            N'@model MoreSpeakers.Domain.Models.Mentorship
 
@@ -198,8 +199,8 @@ VALUES (
        );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+    (Id, Location, Content)
+VALUES (9,
            '/EmailTemplates/MentorshipRequestFromMentee.cshtml',
            '@model MoreSpeakers.Domain.Models.Mentorship
 
@@ -216,8 +217,8 @@ VALUES (
        );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+    (Id, Location, Content)
+VALUES (10,
            '/EmailTemplates/MentorshipRequestToMentor.cshtml',
            '@model MoreSpeakers.Domain.Models.Mentorship
 
@@ -233,8 +234,8 @@ VALUES (
        );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+    (Id, Location, Content)
+VALUES (11,
            '/EmailTemplates/PasswordReset.cshtml',
            '@model MoreSpeakers.Domain.Models.UserPasswordResetEmail;
 
@@ -264,8 +265,8 @@ The MoreSpeakers Team</p>
        );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+    (Id, Location, Content)
+VALUES (12,
            '/EmailTemplates/WelcomeEmail.cshtml',
            N'@model MoreSpeakers.Domain.Models.User
 
@@ -323,3 +324,4 @@ VALUES (
 <p>To activate your account and access all features, please check your email for a confirmation link. If you don''t see it in your inbox, don''t forget to check your spam folder.</p>
 '
        );
+SET IDENTITY_INSERT MoreSpeakers.dbo.EmailTemplates OFF;

--- a/scripts/database/create-tables.sql
+++ b/scripts/database/create-tables.sql
@@ -330,7 +330,8 @@ CREATE INDEX IX_UserSocialMediaSites_UserId
 go
 
 CREATE TABLE [dbo].[EmailTemplates](
-    Location [nvarchar](150) not null primary key,
+    Id INT IDENTITY(1,1) NOT NULL CONSTRAINT PK_EmailTemplates PRIMARY KEY,
+    Location [nvarchar](150) not null unique,
     Content [nvarchar](max) not null,
     CreatedDate datetime2 default getutcdate() not null,
     IsActive [bit] not null default 1,

--- a/scripts/database/seed-data.sql
+++ b/scripts/database/seed-data.sql
@@ -200,9 +200,10 @@ IF NOT EXISTS (SELECT 1 FROM AspNetRoles WHERE NormalizedName = 'MODERATOR')
     VALUES (NEWID(), N'Moderator', N'MODERATOR', CONVERT(nvarchar(128), NEWID()));
 
 
+SET IDENTITY_INSERT MoreSpeakers.dbo.EmailTemplates ON;
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+(Id, Location, Content)
+VALUES (1,
     '/Pages/Shared/_EmailLayout.cshtml',
     N'<!DOCTYPE html>
     <html lang="en">
@@ -253,8 +254,8 @@ VALUES (
     );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+(Id, Location, Content)
+VALUES (2,
     '/EmailTemplates/ConfirmUserEmail.cshtml',
     N'@model MoreSpeakers.Domain.Models.UserConfirmationEmail
 
@@ -273,8 +274,8 @@ In order to take the next step in your journey, please confirm your email addres
     );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+(Id, Location, Content)
+VALUES (3,
     '/EmailTemplates/MentorshipRequestAcceptedFromMentee.cshtml',
     '@model MoreSpeakers.Domain.Models.Mentorship
 
@@ -294,8 +295,8 @@ Layout = "~/Pages/Shared/_EmailLayout.cshtml";
     );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+(Id, Location, Content)
+VALUES (4,
     '/EmailTemplates/MentorshipRequestAcceptedToMentor.cshtml',
     '@model MoreSpeakers.Domain.Models.Mentorship
 
@@ -320,8 +321,8 @@ Phone Number - @Model.Mentee.PhoneNumber
     );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+(Id, Location, Content)
+VALUES (5,
     '/EmailTemplates/MentorshipRequestCancelledFromMentee.cshtml',
     '@model MoreSpeakers.Domain.Models.Mentorship
 
@@ -337,8 +338,8 @@ Layout = "~/Pages/Shared/_EmailLayout.cshtml";
     );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+(Id, Location, Content)
+VALUES (6,
     '/EmailTemplates/MentorshipRequestCancelledToMentor.cshtml',
     '@model MoreSpeakers.Domain.Models.Mentorship
 
@@ -354,8 +355,8 @@ Layout = "~/Pages/Shared/_EmailLayout.cshtml";
     );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+(Id, Location, Content)
+VALUES (7,
     '/EmailTemplates/MentorshipRequestDeclinedFromMentee.cshtml',
     N'@model MoreSpeakers.Domain.Models.Mentorship
 
@@ -373,8 +374,8 @@ Layout = "~/Pages/Shared/_EmailLayout.cshtml";
     );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+(Id, Location, Content)
+VALUES (8,
     '/EmailTemplates/MentorshipRequestDeclinedToMentor.cshtml',
     N'@model MoreSpeakers.Domain.Models.Mentorship
 
@@ -390,8 +391,8 @@ Layout = "~/Pages/Shared/_EmailLayout.cshtml";
     );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+(Id, Location, Content)
+VALUES (9,
     '/EmailTemplates/MentorshipRequestFromMentee.cshtml',
     '@model MoreSpeakers.Domain.Models.Mentorship
 
@@ -408,8 +409,8 @@ Layout = "~/Pages/Shared/_EmailLayout.cshtml";
     );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+(Id, Location, Content)
+VALUES (10,
     '/EmailTemplates/MentorshipRequestToMentor.cshtml',
     '@model MoreSpeakers.Domain.Models.Mentorship
 
@@ -425,8 +426,8 @@ Layout = "~/Pages/Shared/_EmailLayout.cshtml";
     );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+(Id, Location, Content)
+VALUES (11,
     '/EmailTemplates/PasswordReset.cshtml',
     '@model MoreSpeakers.Domain.Models.UserPasswordResetEmail;
 
@@ -456,8 +457,8 @@ The MoreSpeakers Team</p>
     );
 
 INSERT INTO [dbo].[EmailTemplates]
-([Location], [Content])
-VALUES (
+(Id, Location, Content)
+VALUES (12,
     '/EmailTemplates/WelcomeEmail.cshtml',
     N'@model MoreSpeakers.Domain.Models.User
 
@@ -515,3 +516,4 @@ Layout = "~/Pages/Shared/_EmailLayout.cshtml";
 <p>To activate your account and access all features, please check your email for a confirmation link. If you don''t see it in your inbox, don''t forget to check your spam folder.</p>
 '
     );
+SET IDENTITY_INSERT MoreSpeakers.dbo.EmailTemplates OFF;

--- a/src/MoreSpeakers.Data/EmailTemplateDataStore.cs
+++ b/src/MoreSpeakers.Data/EmailTemplateDataStore.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using MoreSpeakers.Domain.Interfaces;
 using MoreSpeakers.Domain.Models;
+using MoreSpeakers.Domain.Models.AdminUsers;
 
 namespace MoreSpeakers.Data;
 
@@ -19,15 +20,15 @@ public class EmailTemplateDataStore : IEmailTemplateDataStore
         _logger = logger;
     }
 
-    public async Task<EmailTemplate?> GetAsync(string primaryKey)
+    public async Task<EmailTemplate?> GetAsync(int primaryKey)
     {
-        var entity = await _context.EmailTemplates.AsNoTracking().FirstOrDefaultAsync(e => e.Location == primaryKey);
+        var entity = await _context.EmailTemplates.AsNoTracking().FirstOrDefaultAsync(e => e.Id == primaryKey);
         return _mapper.Map<EmailTemplate?>(entity);
     }
 
-    public async Task<bool> DeleteAsync(string primaryKey)
+    public async Task<bool> DeleteAsync(int primaryKey)
     {
-        var entity = await _context.EmailTemplates.FirstOrDefaultAsync(e => e.Location == primaryKey);
+        var entity = await _context.EmailTemplates.FirstOrDefaultAsync(e => e.Id == primaryKey);
         if (entity == null)
         {
             return true;
@@ -40,7 +41,7 @@ public class EmailTemplateDataStore : IEmailTemplateDataStore
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to delete email template with location {Location}", primaryKey);
+            _logger.LogError(ex, "Failed to delete email template with id {Id}", primaryKey);
             return false;
         }
     }
@@ -48,9 +49,7 @@ public class EmailTemplateDataStore : IEmailTemplateDataStore
     public async Task<EmailTemplate> SaveAsync(EmailTemplate entity)
     {
         var dbEntity = _mapper.Map<Models.EmailTemplate>(entity);
-        var existing = await _context.EmailTemplates.AnyAsync(e => e.Location == dbEntity.Location);
-        
-        _context.Entry(dbEntity).State = existing ? EntityState.Modified : EntityState.Added;
+        _context.Entry(dbEntity).State = entity.Id == 0 ? EntityState.Added : EntityState.Modified;
 
         try
         {
@@ -62,10 +61,10 @@ public class EmailTemplateDataStore : IEmailTemplateDataStore
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to save email template with location {Location}", entity.Location);
+            _logger.LogError(ex, "Failed to save email template with id {Id}", entity.Id);
         }
 
-        throw new ApplicationException($"Failed to save email template with location {entity.Location}");
+        throw new ApplicationException($"Failed to save email template with id {entity.Id}");
     }
 
     public async Task<List<EmailTemplate>> GetAllAsync()
@@ -74,13 +73,34 @@ public class EmailTemplateDataStore : IEmailTemplateDataStore
         return _mapper.Map<List<EmailTemplate>>(entities);
     }
 
+    public async Task<List<EmailTemplate>> GetAllTemplatesAsync(TriState active = TriState.Any, string? searchTerm = "")
+    {
+        var query = _context.EmailTemplates.AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(searchTerm))
+        {
+            query = query.Where(t => t.Location.Contains(searchTerm));
+        }
+
+        query = active switch
+        {
+            TriState.True => query.Where(t => t.IsActive),
+            TriState.False => query.Where(t => !t.IsActive),
+            _ => query
+        };
+
+        var entities = await query.OrderBy(t => t.Location).AsNoTracking().ToListAsync();
+        return _mapper.Map<List<EmailTemplate>>(entities);
+    }
+
     public async Task<bool> DeleteAsync(EmailTemplate entity)
     {
-        return await DeleteAsync(entity.Location);
+        return await DeleteAsync(entity.Id);
     }
 
     public async Task<EmailTemplate?> GetByLocationAsync(string location)
     {
-        return await GetAsync(location);
+        var entity = await _context.EmailTemplates.AsNoTracking().FirstOrDefaultAsync(e => e.Location == location);
+        return _mapper.Map<EmailTemplate?>(entity);
     }
 }

--- a/src/MoreSpeakers.Data/Models/EmailTemplate.cs
+++ b/src/MoreSpeakers.Data/Models/EmailTemplate.cs
@@ -5,6 +5,9 @@ namespace MoreSpeakers.Data.Models;
 public class EmailTemplate
 {
     [Key]
+    public int Id { get; set; }
+
+    [Required]
     [MaxLength(150)]
     public string Location { get; set; } = string.Empty;
 

--- a/src/MoreSpeakers.Data/MoreSpeakersDbContext.cs
+++ b/src/MoreSpeakers.Data/MoreSpeakersDbContext.cs
@@ -236,12 +236,14 @@ public class MoreSpeakersDbContext
         builder.Entity<EmailTemplate>(entity =>
         {
             entity.ToTable("EmailTemplates");
-            entity.HasKey(e => e.Location);
-            entity.Property(e => e.Location).HasMaxLength(150);
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Location).IsRequired().HasMaxLength(150);
             entity.Property(e => e.Content).IsRequired();
             entity.Property(e => e.CreatedDate).HasDefaultValueSql("GETUTCDATE()");
             entity.Property(e => e.IsActive).HasDefaultValue(true);
             entity.Property(e => e.LastModified).HasDefaultValueSql("GETUTCDATE()");
+
+            entity.HasIndex(e => e.Location).IsUnique();
         });
 
         // Seed initial data

--- a/src/MoreSpeakers.Domain/Interfaces/IEmailTemplateDataStore.cs
+++ b/src/MoreSpeakers.Domain/Interfaces/IEmailTemplateDataStore.cs
@@ -1,8 +1,10 @@
 using MoreSpeakers.Domain.Models;
+using MoreSpeakers.Domain.Models.AdminUsers;
 
 namespace MoreSpeakers.Domain.Interfaces;
 
-public interface IEmailTemplateDataStore : IDataStorePrimaryKeyString<EmailTemplate>
+public interface IEmailTemplateDataStore : IDataStorePrimaryKeyInt<EmailTemplate>
 {
     Task<EmailTemplate?> GetByLocationAsync(string location);
+    Task<List<EmailTemplate>> GetAllTemplatesAsync(TriState active = TriState.Any, string? searchTerm = "");
 }

--- a/src/MoreSpeakers.Domain/Interfaces/IEmailTemplateManager.cs
+++ b/src/MoreSpeakers.Domain/Interfaces/IEmailTemplateManager.cs
@@ -1,11 +1,14 @@
 using MoreSpeakers.Domain.Models;
+using MoreSpeakers.Domain.Models.AdminUsers;
 
 namespace MoreSpeakers.Domain.Interfaces;
 
 public interface IEmailTemplateManager
 {
-    Task<EmailTemplate?> GetAsync(string location);
+    Task<EmailTemplate?> GetAsync(int id);
+    Task<EmailTemplate?> GetByLocationAsync(string location);
     Task<EmailTemplate> SaveAsync(EmailTemplate emailTemplate);
-    Task<bool> DeleteAsync(string location);
+    Task<bool> DeleteAsync(int id);
     Task<List<EmailTemplate>> GetAllAsync();
+    Task<List<EmailTemplate>> GetAllTemplatesAsync(TriState active = TriState.Any, string? searchTerm = "");
 }

--- a/src/MoreSpeakers.Domain/Models/EmailTemplate.cs
+++ b/src/MoreSpeakers.Domain/Models/EmailTemplate.cs
@@ -5,6 +5,9 @@ namespace MoreSpeakers.Domain.Models;
 public class EmailTemplate
 {
     [Key]
+    public int Id { get; set; }
+
+    [Required]
     [MaxLength(150)]
     public string Location { get; set; } = string.Empty;
 

--- a/src/MoreSpeakers.Managers.Tests/EmailTemplateManagerTests.cs
+++ b/src/MoreSpeakers.Managers.Tests/EmailTemplateManagerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using MoreSpeakers.Domain.Interfaces;
 using MoreSpeakers.Domain.Models;
+using MoreSpeakers.Domain.Models.AdminUsers;
 
 namespace MoreSpeakers.Managers.Tests;
 
@@ -16,28 +17,42 @@ public class EmailTemplateManagerTests
     [Fact]
     public async Task GetAsync_should_delegate()
     {
-        var location = "Templates/Welcome.cshtml";
-        _dataStoreMock.Setup(d => d.GetAsync(location)).ReturnsAsync(new EmailTemplate { Location = location });
+        var id = 1;
+        _dataStoreMock.Setup(d => d.GetAsync(id)).ReturnsAsync(new EmailTemplate { Id = id });
         var sut = CreateSut();
 
-        var result = await sut.GetAsync(location);
+        var result = await sut.GetAsync(id);
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(id);
+        _dataStoreMock.Verify(d => d.GetAsync(id), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetByLocationAsync_should_delegate()
+    {
+        var location = "Templates/Welcome.cshtml";
+        _dataStoreMock.Setup(d => d.GetByLocationAsync(location)).ReturnsAsync(new EmailTemplate { Location = location });
+        var sut = CreateSut();
+
+        var result = await sut.GetByLocationAsync(location);
 
         result.Should().NotBeNull();
         result!.Location.Should().Be(location);
-        _dataStoreMock.Verify(d => d.GetAsync(location), Times.Once);
+        _dataStoreMock.Verify(d => d.GetByLocationAsync(location), Times.Once);
     }
 
     [Fact]
     public async Task DeleteAsync_should_delegate()
     {
-        var location = "Templates/Old.cshtml";
-        _dataStoreMock.Setup(d => d.DeleteAsync(location)).ReturnsAsync(true);
+        var id = 1;
+        _dataStoreMock.Setup(d => d.DeleteAsync(id)).ReturnsAsync(true);
         var sut = CreateSut();
 
-        var result = await sut.DeleteAsync(location);
+        var result = await sut.DeleteAsync(id);
 
         result.Should().BeTrue();
-        _dataStoreMock.Verify(d => d.DeleteAsync(location), Times.Once);
+        _dataStoreMock.Verify(d => d.DeleteAsync(id), Times.Once);
     }
 
     [Fact]
@@ -64,5 +79,20 @@ public class EmailTemplateManagerTests
 
         result.Should().BeSameAs(expected);
         _dataStoreMock.Verify(d => d.GetAllAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllTemplatesAsync_with_filters_should_delegate()
+    {
+        var expected = new List<EmailTemplate> { new() { Location = "L1" } };
+        var active = TriState.True;
+        var q = "test";
+        _dataStoreMock.Setup(d => d.GetAllTemplatesAsync(active, q)).ReturnsAsync(expected);
+        var sut = CreateSut();
+
+        var result = await sut.GetAllTemplatesAsync(active, q);
+
+        result.Should().BeSameAs(expected);
+        _dataStoreMock.Verify(d => d.GetAllTemplatesAsync(active, q), Times.Once);
     }
 }

--- a/src/MoreSpeakers.Managers.Tests/Providers/DatabaseFileProviderTests.cs
+++ b/src/MoreSpeakers.Managers.Tests/Providers/DatabaseFileProviderTests.cs
@@ -23,7 +23,7 @@ public class DatabaseFileProviderTests
         // Arrange
         var path = "Templates/Welcome.cshtml";
         var template = new EmailTemplate { Location = path, Content = "Welcome!" };
-        _managerMock.Setup(m => m.GetAsync(path)).ReturnsAsync(template);
+        _managerMock.Setup(m => m.GetByLocationAsync(path)).ReturnsAsync(template);
 
         // Act
         var result = _provider.GetFileInfo(path);
@@ -32,7 +32,7 @@ public class DatabaseFileProviderTests
         result.Should().NotBeNull();
         result.Exists.Should().BeTrue();
         result.Name.Should().Be(path);
-        _managerMock.Verify(m => m.GetAsync(path), Times.Once);
+        _managerMock.Verify(m => m.GetByLocationAsync(path), Times.Once);
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public class DatabaseFileProviderTests
     {
         // Arrange
         var path = "Missing.cshtml";
-        _managerMock.Setup(m => m.GetAsync(path)).ReturnsAsync((EmailTemplate?)null);
+        _managerMock.Setup(m => m.GetByLocationAsync(path)).ReturnsAsync((EmailTemplate?)null);
 
         // Act
         var result = _provider.GetFileInfo(path);
@@ -66,7 +66,7 @@ public class DatabaseFileProviderTests
         // Arrange
         var filter = "Templates/Welcome.cshtml";
         var template = new EmailTemplate { Location = filter };
-        _managerMock.Setup(m => m.GetAsync(filter)).ReturnsAsync(template);
+        _managerMock.Setup(m => m.GetByLocationAsync(filter)).ReturnsAsync(template);
 
         // Act
         var result = _provider.Watch(filter);
@@ -80,7 +80,7 @@ public class DatabaseFileProviderTests
     {
         // Arrange
         var filter = "Missing.cshtml";
-        _managerMock.Setup(m => m.GetAsync(filter)).ReturnsAsync((EmailTemplate?)null);
+        _managerMock.Setup(m => m.GetByLocationAsync(filter)).ReturnsAsync((EmailTemplate?)null);
 
         // Act
         var result = _provider.Watch(filter);

--- a/src/MoreSpeakers.Managers/EmailTemplateManager.cs
+++ b/src/MoreSpeakers.Managers/EmailTemplateManager.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using MoreSpeakers.Domain.Interfaces;
 using MoreSpeakers.Domain.Models;
+using MoreSpeakers.Domain.Models.AdminUsers;
 
 namespace MoreSpeakers.Managers;
 
@@ -15,9 +16,14 @@ public class EmailTemplateManager : IEmailTemplateManager
         _logger = logger;
     }
 
-    public async Task<EmailTemplate?> GetAsync(string location)
+    public async Task<EmailTemplate?> GetAsync(int id)
     {
-        return await _dataStore.GetAsync(location);
+        return await _dataStore.GetAsync(id);
+    }
+
+    public async Task<EmailTemplate?> GetByLocationAsync(string location)
+    {
+        return await _dataStore.GetByLocationAsync(location);
     }
 
     public async Task<EmailTemplate> SaveAsync(EmailTemplate emailTemplate)
@@ -25,13 +31,18 @@ public class EmailTemplateManager : IEmailTemplateManager
         return await _dataStore.SaveAsync(emailTemplate);
     }
 
-    public async Task<bool> DeleteAsync(string location)
+    public async Task<bool> DeleteAsync(int id)
     {
-        return await _dataStore.DeleteAsync(location);
+        return await _dataStore.DeleteAsync(id);
     }
 
     public async Task<List<EmailTemplate>> GetAllAsync()
     {
         return await _dataStore.GetAllAsync();
+    }
+
+    public async Task<List<EmailTemplate>> GetAllTemplatesAsync(TriState active = TriState.Any, string? searchTerm = "")
+    {
+        return await _dataStore.GetAllTemplatesAsync(active, searchTerm);
     }
 }

--- a/src/MoreSpeakers.Managers/Providers/DatabaseFileProvider.cs
+++ b/src/MoreSpeakers.Managers/Providers/DatabaseFileProvider.cs
@@ -20,7 +20,7 @@ public class DatabaseFileProvider : IFileProvider
             return new NotFoundFileInfo(subpath);
         }
 
-        var template = _emailTemplateManager.GetAsync(subpath).GetAwaiter().GetResult();
+        var template = _emailTemplateManager.GetByLocationAsync(subpath).GetAwaiter().GetResult();
         return template != null ? new DatabaseFileInfo(template, subpath) : new NotFoundFileInfo(subpath);
     }
 
@@ -36,7 +36,7 @@ public class DatabaseFileProvider : IFileProvider
             return NullChangeToken.Singleton;
         }
 
-        var template = _emailTemplateManager.GetAsync(filter).GetAwaiter().GetResult();
+        var template = _emailTemplateManager.GetByLocationAsync(filter).GetAwaiter().GetResult();
         return template != null ? new DatabaseChangeToken(template) : NullChangeToken.Singleton;
     }
 }

--- a/src/MoreSpeakers.Web.Tests/Areas/Admin/Pages/Catalog/EmailTemplates/CreatePageTests.cs
+++ b/src/MoreSpeakers.Web.Tests/Areas/Admin/Pages/Catalog/EmailTemplates/CreatePageTests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Logging;
+using Moq;
+using MoreSpeakers.Domain.Interfaces;
+using MoreSpeakers.Domain.Models;
+using MoreSpeakers.Web.Areas.Admin.Pages.Catalog.EmailTemplates;
+
+namespace MoreSpeakers.Web.Tests.Areas.Admin.Pages.Catalog.EmailTemplates;
+
+public class CreatePageTests
+{
+    private readonly Mock<IEmailTemplateManager> _managerMock = new();
+    private readonly Mock<ILogger<CreateModel>> _loggerMock = new();
+
+    [Fact]
+    public async Task OnPostAsync_ShouldReturnPage_WhenModelStateIsInvalid()
+    {
+        // Arrange
+        var page = new CreateModel(_managerMock.Object, _loggerMock.Object);
+        page.ModelState.AddModelError("Error", "Required");
+
+        // Act
+        var result = await page.OnPostAsync();
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+        _managerMock.Verify(m => m.SaveAsync(It.IsAny<EmailTemplate>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task OnPostAsync_ShouldReturnPage_WhenLocationAlreadyExists()
+    {
+        // Arrange
+        var location = "Templates/Welcome.cshtml";
+        _managerMock.Setup(m => m.GetByLocationAsync(location)).ReturnsAsync(new EmailTemplate { Location = location });
+        var page = new CreateModel(_managerMock.Object, _loggerMock.Object)
+        {
+            Input = new CreateModel.InputModel { Location = location, Content = "Some content" }
+        };
+
+        // Act
+        var result = await page.OnPostAsync();
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+        page.ModelState.ContainsKey("Input.Location").Should().BeTrue();
+        _managerMock.Verify(m => m.SaveAsync(It.IsAny<EmailTemplate>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task OnPostAsync_ShouldSaveAndRedirect_WhenValid()
+    {
+        // Arrange
+        var location = "Templates/New.cshtml";
+        _managerMock.Setup(m => m.GetByLocationAsync(location)).ReturnsAsync((EmailTemplate?)null);
+        _managerMock.Setup(m => m.SaveAsync(It.IsAny<EmailTemplate>())).ReturnsAsync((EmailTemplate t) => t);
+        
+        var page = new CreateModel(_managerMock.Object, _loggerMock.Object)
+        {
+            Input = new CreateModel.InputModel { Location = location, Content = "Hello World", IsActive = true }
+        };
+
+        // Act
+        var result = await page.OnPostAsync();
+
+        // Assert
+        result.Should().BeOfType<RedirectToPageResult>().Which.PageName.Should().Be("Index");
+        _managerMock.Verify(m => m.SaveAsync(It.Is<EmailTemplate>(t => t.Location == location && t.Content == "Hello World")), Times.Once);
+    }
+}

--- a/src/MoreSpeakers.Web.Tests/Areas/Admin/Pages/Catalog/EmailTemplates/DeletePageTests.cs
+++ b/src/MoreSpeakers.Web.Tests/Areas/Admin/Pages/Catalog/EmailTemplates/DeletePageTests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Logging;
+using Moq;
+using MoreSpeakers.Domain.Interfaces;
+using MoreSpeakers.Domain.Models;
+using MoreSpeakers.Web.Areas.Admin.Pages.Catalog.EmailTemplates;
+
+namespace MoreSpeakers.Web.Tests.Areas.Admin.Pages.Catalog.EmailTemplates;
+
+public class DeletePageTests
+{
+    private readonly Mock<IEmailTemplateManager> _managerMock = new();
+    private readonly Mock<ILogger<DeleteModel>> _loggerMock = new();
+
+    [Fact]
+    public async Task OnGetAsync_ShouldRedirectToIndex_WhenTemplateDoesNotExist()
+    {
+        // Arrange
+        _managerMock.Setup(m => m.GetAsync(999)).ReturnsAsync((EmailTemplate?)null);
+        var page = new DeleteModel(_managerMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await page.OnGetAsync(999);
+
+        // Assert
+        result.Should().BeOfType<RedirectToPageResult>().Which.PageName.Should().Be("Index");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_ShouldReturnPage_WhenTemplateExists()
+    {
+        // Arrange
+        var template = new EmailTemplate { Id = 1, Location = "exists" };
+        _managerMock.Setup(m => m.GetAsync(1)).ReturnsAsync(template);
+        var page = new DeleteModel(_managerMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await page.OnGetAsync(1);
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+        page.EmailTemplate.Should().BeEquivalentTo(template);
+    }
+
+    [Fact]
+    public async Task OnPostAsync_ShouldDeleteAndRedirectToIndex_WhenValid()
+    {
+        // Arrange
+        var id = 1;
+        _managerMock.Setup(m => m.GetAsync(id)).ReturnsAsync(new EmailTemplate { Id = id, Location = "L" });
+        _managerMock.Setup(m => m.DeleteAsync(id)).ReturnsAsync(true);
+        var page = new DeleteModel(_managerMock.Object, _loggerMock.Object) { Id = id };
+
+        // Act
+        var result = await page.OnPostAsync();
+
+        // Assert
+        result.Should().BeOfType<RedirectToPageResult>().Which.PageName.Should().Be("Index");
+        _managerMock.Verify(m => m.DeleteAsync(id), Times.Once);
+    }
+}

--- a/src/MoreSpeakers.Web.Tests/Areas/Admin/Pages/Catalog/EmailTemplates/DetailsPageTests.cs
+++ b/src/MoreSpeakers.Web.Tests/Areas/Admin/Pages/Catalog/EmailTemplates/DetailsPageTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Moq;
+using MoreSpeakers.Domain.Interfaces;
+using MoreSpeakers.Domain.Models;
+using MoreSpeakers.Web.Areas.Admin.Pages.Catalog.EmailTemplates;
+
+namespace MoreSpeakers.Web.Tests.Areas.Admin.Pages.Catalog.EmailTemplates;
+
+public class DetailsPageTests
+{
+    private readonly Mock<IEmailTemplateManager> _managerMock = new();
+
+    [Fact]
+    public async Task OnGetAsync_ShouldReturnNotFound_WhenTemplateDoesNotExist()
+    {
+        // Arrange
+        _managerMock.Setup(m => m.GetAsync(999)).ReturnsAsync((EmailTemplate?)null);
+        var page = new DetailsModel(_managerMock.Object);
+
+        // Act
+        var result = await page.OnGetAsync(999);
+
+        // Assert
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task OnGetAsync_ShouldReturnPage_WhenTemplateExists()
+    {
+        // Arrange
+        var template = new EmailTemplate { Id = 1, Location = "exists", Content = "content" };
+        _managerMock.Setup(m => m.GetAsync(1)).ReturnsAsync(template);
+        var page = new DetailsModel(_managerMock.Object);
+
+        // Act
+        var result = await page.OnGetAsync(1);
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+        page.EmailTemplate.Should().BeEquivalentTo(template);
+    }
+}

--- a/src/MoreSpeakers.Web.Tests/Areas/Admin/Pages/Catalog/EmailTemplates/EditPageTests.cs
+++ b/src/MoreSpeakers.Web.Tests/Areas/Admin/Pages/Catalog/EmailTemplates/EditPageTests.cs
@@ -1,0 +1,141 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Logging;
+using Moq;
+using MoreSpeakers.Domain.Interfaces;
+using MoreSpeakers.Domain.Models;
+using MoreSpeakers.Web.Areas.Admin.Pages.Catalog.EmailTemplates;
+
+namespace MoreSpeakers.Web.Tests.Areas.Admin.Pages.Catalog.EmailTemplates;
+
+public class EditPageTests
+{
+    private readonly Mock<IEmailTemplateManager> _managerMock = new();
+    private readonly Mock<ILogger<EditModel>> _loggerMock = new();
+
+    [Fact]
+    public async Task OnGetAsync_ShouldRedirectToIndex_WhenTemplateDoesNotExist()
+    {
+        // Arrange
+        _managerMock.Setup(m => m.GetAsync(999)).ReturnsAsync((EmailTemplate?)null);
+        var page = new EditModel(_managerMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await page.OnGetAsync(999);
+
+        // Assert
+        result.Should().BeOfType<RedirectToPageResult>().Which.PageName.Should().Be("Index");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_ShouldReturnPage_WhenTemplateExists()
+    {
+        // Arrange
+        var template = new EmailTemplate { Id = 1, Location = "exists", Content = "content", IsActive = true };
+        _managerMock.Setup(m => m.GetAsync(1)).ReturnsAsync(template);
+        var page = new EditModel(_managerMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await page.OnGetAsync(1);
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+        page.Input.Location.Should().Be("exists");
+        page.Input.Content.Should().Be("content");
+        page.Input.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OnPostAsync_ShouldReturnPage_WhenModelStateIsInvalid()
+    {
+        // Arrange
+        var page = new EditModel(_managerMock.Object, _loggerMock.Object);
+        page.ModelState.AddModelError("Error", "Required");
+
+        // Act
+        var result = await page.OnPostAsync();
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+        _managerMock.Verify(m => m.SaveAsync(It.IsAny<EmailTemplate>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task OnPostAsync_ShouldReturnPage_WhenLocationAlreadyExistsForAnotherTemplate()
+    {
+        // Arrange
+        var id = 1;
+        var existingLocation = "Templates/Existing.cshtml";
+        var template = new EmailTemplate { Id = id, Location = "Templates/Old.cshtml" };
+        
+        _managerMock.Setup(m => m.GetAsync(id)).ReturnsAsync(template);
+        _managerMock.Setup(m => m.GetByLocationAsync(existingLocation)).ReturnsAsync(new EmailTemplate { Id = 2, Location = existingLocation });
+        
+        var page = new EditModel(_managerMock.Object, _loggerMock.Object)
+        {
+            Id = id,
+            Input = new EditModel.InputModel { Location = existingLocation, Content = "New Content" }
+        };
+
+        // Act
+        var result = await page.OnPostAsync();
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+        page.ModelState.ContainsKey("Input.Location").Should().BeTrue();
+        _managerMock.Verify(m => m.SaveAsync(It.IsAny<EmailTemplate>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task OnPostAsync_ShouldSaveAndRedirect_WhenValid()
+    {
+        // Arrange
+        var id = 1;
+        var location = "Templates/Updated.cshtml";
+        var template = new EmailTemplate { Id = id, Location = "Templates/Old.cshtml", Content = "Old Content" };
+        
+        _managerMock.Setup(m => m.GetAsync(id)).ReturnsAsync(template);
+        _managerMock.Setup(m => m.GetByLocationAsync(location)).ReturnsAsync((EmailTemplate?)null);
+        _managerMock.Setup(m => m.SaveAsync(It.IsAny<EmailTemplate>())).ReturnsAsync((EmailTemplate t) => t);
+        
+        var page = new EditModel(_managerMock.Object, _loggerMock.Object)
+        {
+            Id = id,
+            Input = new EditModel.InputModel { Location = location, Content = "Updated Content", IsActive = false }
+        };
+
+        // Act
+        var result = await page.OnPostAsync();
+
+        // Assert
+        result.Should().BeOfType<RedirectToPageResult>().Which.PageName.Should().Be("Index");
+        _managerMock.Verify(m => m.SaveAsync(It.Is<EmailTemplate>(t => t.Id == id && t.Location == location && t.Content == "Updated Content" && !t.IsActive)), Times.Once);
+    }
+
+    [Fact]
+    public async Task OnPostAsync_ShouldSaveAndRedirect_WhenLocationUnchanged()
+    {
+        // Arrange
+        var id = 1;
+        var location = "Templates/Same.cshtml";
+        var template = new EmailTemplate { Id = id, Location = location, Content = "Old Content" };
+
+        _managerMock.Setup(m => m.GetAsync(id)).ReturnsAsync(template);
+        _managerMock.Setup(m => m.SaveAsync(It.IsAny<EmailTemplate>())).ReturnsAsync((EmailTemplate t) => t);
+
+        var page = new EditModel(_managerMock.Object, _loggerMock.Object)
+        {
+            Id = id,
+            Input = new EditModel.InputModel { Location = location, Content = "Updated Content", IsActive = true }
+        };
+
+        // Act
+        var result = await page.OnPostAsync();
+
+        // Assert
+        result.Should().BeOfType<RedirectToPageResult>().Which.PageName.Should().Be("Index");
+        _managerMock.Verify(m => m.GetByLocationAsync(It.IsAny<string>()), Times.Never);
+        _managerMock.Verify(m => m.SaveAsync(It.Is<EmailTemplate>(t => t.Id == id && t.Location == location && t.Content == "Updated Content")), Times.Once);
+    }
+}

--- a/src/MoreSpeakers.Web.Tests/Areas/Admin/Pages/Catalog/EmailTemplates/IndexPageTests.cs
+++ b/src/MoreSpeakers.Web.Tests/Areas/Admin/Pages/Catalog/EmailTemplates/IndexPageTests.cs
@@ -1,0 +1,95 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Logging;
+using Moq;
+using MoreSpeakers.Domain.Interfaces;
+using MoreSpeakers.Domain.Models;
+using MoreSpeakers.Domain.Models.AdminUsers;
+using MoreSpeakers.Web.Areas.Admin.Pages.Catalog.EmailTemplates;
+
+namespace MoreSpeakers.Web.Tests.Areas.Admin.Pages.Catalog.EmailTemplates;
+
+public class IndexPageTests
+{
+    private readonly Mock<IEmailTemplateManager> _managerMock = new();
+    private readonly Mock<ILogger<IndexModel>> _loggerMock = new();
+
+    [Fact]
+    public async Task OnGetAsync_ShouldLoadAllItems_WhenNoQuery()
+    {
+        // Arrange
+        var items = new List<EmailTemplate>
+        {
+            new() { Location = "A" },
+            new() { Location = "B" },
+        };
+        _managerMock.Setup(m => m.GetAllTemplatesAsync(TriState.Any, null)).ReturnsAsync(items);
+        var page = new IndexModel(_managerMock.Object, _loggerMock.Object);
+
+        // Act
+        await page.OnGetAsync();
+
+        // Assert
+        page.Items.Should().BeEquivalentTo(items);
+        _managerMock.Verify(m => m.GetAllTemplatesAsync(TriState.Any, null), Times.Once);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_ShouldFilterByQueryAndStatus()
+    {
+        // Arrange
+        var items = new List<EmailTemplate> { new() { Location = "Welcome" } };
+        _managerMock.Setup(m => m.GetAllTemplatesAsync(TriState.True, "welcome")).ReturnsAsync(items);
+        var page = new IndexModel(_managerMock.Object, _loggerMock.Object)
+        {
+            Q = "welcome",
+            Status = TriState.True
+        };
+
+        // Act
+        await page.OnGetAsync();
+
+        // Assert
+        page.Items.Should().BeEquivalentTo(items);
+        _managerMock.Verify(m => m.GetAllTemplatesAsync(TriState.True, "welcome"), Times.Once);
+    }
+
+    [Fact]
+    public async Task OnPostDeactivateAsync_ShouldDeactivateAndRedirect()
+    {
+        // Arrange
+        var id = 1;
+        var template = new EmailTemplate { Id = id, Location = "L", IsActive = true };
+        _managerMock.Setup(m => m.GetAsync(id)).ReturnsAsync(template);
+        _managerMock.Setup(m => m.SaveAsync(It.IsAny<EmailTemplate>())).ReturnsAsync((EmailTemplate t) => t);
+        var page = new IndexModel(_managerMock.Object, _loggerMock.Object) { Q = "q", Status = TriState.Any };
+
+        // Act
+        var result = await page.OnPostDeactivateAsync(id);
+
+        // Assert
+        result.Should().BeOfType<RedirectToPageResult>();
+        template.IsActive.Should().BeFalse();
+        _managerMock.Verify(m => m.SaveAsync(It.Is<EmailTemplate>(t => t.Id == id && !t.IsActive)), Times.Once);
+    }
+
+    [Fact]
+    public async Task OnPostActivateAsync_ShouldActivateAndRedirect()
+    {
+        // Arrange
+        var id = 1;
+        var template = new EmailTemplate { Id = id, Location = "L", IsActive = false };
+        _managerMock.Setup(m => m.GetAsync(id)).ReturnsAsync(template);
+        _managerMock.Setup(m => m.SaveAsync(It.IsAny<EmailTemplate>())).ReturnsAsync((EmailTemplate t) => t);
+        var page = new IndexModel(_managerMock.Object, _loggerMock.Object) { Q = "q", Status = TriState.Any };
+
+        // Act
+        var result = await page.OnPostActivateAsync(id);
+
+        // Assert
+        result.Should().BeOfType<RedirectToPageResult>();
+        template.IsActive.Should().BeTrue();
+        _managerMock.Verify(m => m.SaveAsync(It.Is<EmailTemplate>(t => t.Id == id && t.IsActive)), Times.Once);
+    }
+}

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Create.cshtml
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Create.cshtml
@@ -1,0 +1,54 @@
+@page
+@model MoreSpeakers.Web.Areas.Admin.Pages.Catalog.EmailTemplates.CreateModel
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+@{
+    ViewData["Title"] = "New Email Template";
+}
+
+<h1 class="mb-4">New Email Template</h1>
+
+<nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Index">Admin</a></li>
+        <li class="breadcrumb-item"><a asp-page="Index">Email Templates</a></li>
+        <li class="breadcrumb-item active" aria-current="page">New</li>
+    </ol>
+</nav>
+
+<div class="card shadow-sm">
+    <div class="card-body">
+        <form method="post">
+            <div asp-validation-summary="ModelOnly" class="text-danger mb-3" role="alert"></div>
+
+            <div class="mb-3">
+                <label asp-for="Input.Location" class="form-label">Location</label>
+                <input asp-for="Input.Location" class="form-control" placeholder="e.g., Templates/Welcome.cshtml" />
+                <span asp-validation-for="Input.Location" class="text-danger"></span>
+                <div class="form-text">The virtual path used to retrieve the template.</div>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Input.Content" class="form-label">Content</label>
+                <textarea asp-for="Input.Content" class="form-control" rows="15" placeholder="Razor/HTML content..."></textarea>
+                <span asp-validation-for="Input.Content" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3 form-check">
+                <input asp-for="Input.IsActive" class="form-check-input" />
+                <label asp-for="Input.IsActive" class="form-check-label">Is Active</label>
+            </div>
+
+            <div class="mt-4">
+                <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-check-lg me-1"></i>Create Template
+                </button>
+                <a asp-page="Index" class="btn btn-outline-secondary ms-2">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Create.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Create.cshtml.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using MoreSpeakers.Domain.Interfaces;
+using MoreSpeakers.Domain.Models;
+
+namespace MoreSpeakers.Web.Areas.Admin.Pages.Catalog.EmailTemplates;
+
+public class CreateModel(IEmailTemplateManager emailTemplateManager, ILogger<CreateModel> logger) : PageModel
+{
+    private readonly IEmailTemplateManager _emailTemplateManager = emailTemplateManager;
+    private readonly ILogger<CreateModel> _logger = logger;
+
+    public class InputModel
+    {
+        [Required]
+        [MaxLength(150)]
+        public string Location { get; set; } = string.Empty;
+
+        [Required]
+        public string Content { get; set; } = string.Empty;
+
+        public bool IsActive { get; set; } = true;
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        // Check if a template with this location already exists
+        EmailTemplate? existing = await _emailTemplateManager.GetByLocationAsync(Input.Location);
+        if (existing != null)
+        {
+            ModelState.AddModelError("Input.Location", "An email template with this location already exists.");
+            return Page();
+        }
+
+        EmailTemplate template = new EmailTemplate
+        {
+            Location = Input.Location.Trim(),
+            Content = Input.Content,
+            IsActive = Input.IsActive,
+            CreatedDate = DateTime.UtcNow,
+            LastModified = DateTime.UtcNow
+        };
+
+        await _emailTemplateManager.SaveAsync(template);
+        _logger.LogInformation("[Admin:EmailTemplates] Created email template {Location}", template.Location);
+
+        return RedirectToPage("Index");
+    }
+}

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Delete.cshtml
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Delete.cshtml
@@ -1,0 +1,42 @@
+@page "{id:int}"
+@model MoreSpeakers.Web.Areas.Admin.Pages.Catalog.EmailTemplates.DeleteModel
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+@{
+    ViewData["Title"] = "Delete Email Template";
+}
+
+<h1 class="mb-4">Delete Email Template</h1>
+
+<nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Index">Admin</a></li>
+        <li class="breadcrumb-item"><a asp-page="Index">Email Templates</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Delete</li>
+    </ol>
+</nav>
+
+<div class="alert alert-danger mb-4">
+    <h4 class="alert-heading"><i class="bi bi-exclamation-triangle-fill me-2"></i>Warning!</h4>
+    <p>Are you sure you want to delete this email template? This action cannot be undone.</p>
+</div>
+
+<div class="card shadow-sm mb-4">
+    <div class="card-body">
+        <dl class="row mb-0">
+            <dt class="col-sm-3">Location</dt>
+            <dd class="col-sm-9"><code>@Model.EmailTemplate.Location</code></dd>
+
+            <dt class="col-sm-3">Last Modified</dt>
+            <dd class="col-sm-9">@Model.EmailTemplate.LastModified.ToString("F")</dd>
+        </dl>
+    </div>
+</div>
+
+<form method="post">
+    <input type="hidden" asp-for="Id" />
+    <button type="submit" class="btn btn-danger">
+        <i class="bi bi-trash3 me-1"></i>Confirm Delete
+    </button>
+    <a asp-page="Index" class="btn btn-outline-secondary ms-2">Cancel</a>
+</form>

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Delete.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Delete.cshtml.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using MoreSpeakers.Domain.Interfaces;
+using MoreSpeakers.Domain.Models;
+
+namespace MoreSpeakers.Web.Areas.Admin.Pages.Catalog.EmailTemplates;
+
+public class DeleteModel(IEmailTemplateManager emailTemplateManager, ILogger<DeleteModel> logger) : PageModel
+{
+    private readonly IEmailTemplateManager _emailTemplateManager = emailTemplateManager;
+    private readonly ILogger<DeleteModel> _logger = logger;
+
+    [BindProperty(SupportsGet = true)]
+    public int Id { get; set; }
+
+    public EmailTemplate EmailTemplate { get; private set; } = null!;
+
+    public async Task<IActionResult> OnGetAsync(int id)
+    {
+        EmailTemplate? template = await _emailTemplateManager.GetAsync(id);
+        if (template == null)
+        {
+            return RedirectToPage("Index");
+        }
+
+        Id = id;
+        EmailTemplate = template;
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        EmailTemplate? template = await _emailTemplateManager.GetAsync(Id);
+        string location = template?.Location ?? Id.ToString();
+
+        await _emailTemplateManager.DeleteAsync(Id);
+        _logger.LogInformation("[Admin:EmailTemplates] Deleted email template {Id} {Location}", Id, location);
+
+        return RedirectToPage("Index");
+    }
+}

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Details.cshtml
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Details.cshtml
@@ -1,0 +1,72 @@
+@page "{id:int}"
+@model MoreSpeakers.Web.Areas.Admin.Pages.Catalog.EmailTemplates.DetailsModel
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+@{
+    ViewData["Title"] = "Email Template Details";
+}
+
+<h1 class="mb-4">Email Template Details</h1>
+
+<nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Index">Admin</a></li>
+        <li class="breadcrumb-item"><a asp-page="Index">Email Templates</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Details</li>
+    </ol>
+</nav>
+
+<div class="card shadow-sm mb-4">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <h5 class="mb-0">Metadata</h5>
+        <div>
+            @if (Model.EmailTemplate.IsActive)
+            {
+                <span class="badge bg-success">Active</span>
+            }
+            else
+            {
+                <span class="badge bg-secondary">Inactive</span>
+            }
+        </div>
+    </div>
+    <div class="card-body">
+        <dl class="row mb-0">
+            <dt class="col-sm-3">Location</dt>
+            <dd class="col-sm-9"><code>@Model.EmailTemplate.Location</code></dd>
+
+            <dt class="col-sm-3">Created Date</dt>
+            <dd class="col-sm-9">@Model.EmailTemplate.CreatedDate.ToString("F")</dd>
+
+            <dt class="col-sm-3">Last Modified</dt>
+            <dd class="col-sm-9">@Model.EmailTemplate.LastModified.ToString("F")</dd>
+
+            @if (Model.EmailTemplate.LastRequested.HasValue)
+            {
+                <dt class="col-sm-3">Last Requested</dt>
+                <dd class="col-sm-9">@Model.EmailTemplate.LastRequested.Value.ToString("F")</dd>
+            }
+        </dl>
+    </div>
+</div>
+
+<div class="card shadow-sm mb-4">
+    <div class="card-header">
+        <h5 class="mb-0">Content</h5>
+    </div>
+    <div class="card-body p-0">
+        <pre class="bg-light p-3 mb-0" style="max-height: 600px; overflow-y: auto;"><code>@Model.EmailTemplate.Content</code></pre>
+    </div>
+</div>
+
+<div class="mb-5">
+    <a asp-page="Index" class="btn btn-outline-secondary">
+        <i class="bi bi-arrow-left me-1"></i>Back to List
+    </a>
+    <a asp-page="Edit" asp-route-id="@Model.EmailTemplate.Id" class="btn btn-primary ms-2">
+        <i class="bi bi-pencil me-1"></i>Edit
+    </a>
+    <a asp-page="Delete" asp-route-id="@Model.EmailTemplate.Id" class="btn btn-danger ms-2">
+        <i class="bi bi-trash3 me-1"></i>Delete
+    </a>
+</div>

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Details.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Details.cshtml.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using MoreSpeakers.Domain.Interfaces;
+using MoreSpeakers.Domain.Models;
+
+namespace MoreSpeakers.Web.Areas.Admin.Pages.Catalog.EmailTemplates;
+
+public class DetailsModel(IEmailTemplateManager emailTemplateManager) : PageModel
+{
+    private readonly IEmailTemplateManager _emailTemplateManager = emailTemplateManager;
+
+    public EmailTemplate EmailTemplate { get; private set; } = null!;
+
+    public async Task<IActionResult> OnGetAsync(int id)
+    {
+        EmailTemplate? template = await _emailTemplateManager.GetAsync(id);
+
+        if (template == null)
+        {
+            return NotFound();
+        }
+
+        EmailTemplate = template;
+        return Page();
+    }
+}

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Edit.cshtml
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Edit.cshtml
@@ -1,0 +1,55 @@
+@page "{id:int}"
+@model MoreSpeakers.Web.Areas.Admin.Pages.Catalog.EmailTemplates.EditModel
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+@{
+    ViewData["Title"] = "Edit Email Template";
+}
+
+<h1 class="mb-4">Edit Email Template</h1>
+
+<nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Index">Admin</a></li>
+        <li class="breadcrumb-item"><a asp-page="Index">Email Templates</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Edit</li>
+    </ol>
+</nav>
+
+<div class="card shadow-sm">
+    <div class="card-body">
+        <form method="post">
+            <div asp-validation-summary="ModelOnly" class="text-danger mb-3" role="alert"></div>
+            <input type="hidden" asp-for="Id" />
+
+            <div class="mb-3">
+                <label asp-for="Input.Location" class="form-label">Location</label>
+                <input asp-for="Input.Location" class="form-control" placeholder="e.g., Templates/Welcome.cshtml" />
+                <span asp-validation-for="Input.Location" class="text-danger"></span>
+                <div class="form-text">The virtual path used to retrieve the template.</div>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Input.Content" class="form-label">Content</label>
+                <textarea asp-for="Input.Content" class="form-control" rows="15" placeholder="Razor/HTML content..."></textarea>
+                <span asp-validation-for="Input.Content" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3 form-check">
+                <input asp-for="Input.IsActive" class="form-check-input" />
+                <label asp-for="Input.IsActive" class="form-check-label">Is Active</label>
+            </div>
+
+            <div class="mt-4">
+                <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-save me-1"></i>Save Changes
+                </button>
+                <a asp-page="Index" class="btn btn-outline-secondary ms-2">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Edit.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Edit.cshtml.cs
@@ -1,0 +1,84 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using MoreSpeakers.Domain.Interfaces;
+using MoreSpeakers.Domain.Models;
+
+namespace MoreSpeakers.Web.Areas.Admin.Pages.Catalog.EmailTemplates;
+
+public class EditModel(IEmailTemplateManager emailTemplateManager, ILogger<EditModel> logger) : PageModel
+{
+    private readonly IEmailTemplateManager _emailTemplateManager = emailTemplateManager;
+    private readonly ILogger<EditModel> _logger = logger;
+
+    [BindProperty(SupportsGet = true)]
+    public int Id { get; set; }
+
+    public class InputModel
+    {
+        [Required]
+        [MaxLength(150)]
+        public string Location { get; set; } = string.Empty;
+
+        [Required]
+        public string Content { get; set; } = string.Empty;
+
+        public bool IsActive { get; set; } = true;
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public async Task<IActionResult> OnGetAsync(int id)
+    {
+        EmailTemplate? template = await _emailTemplateManager.GetAsync(id);
+        if (template == null)
+        {
+            return RedirectToPage("Index");
+        }
+
+        Id = id;
+        Input = new InputModel
+        {
+            Location = template.Location,
+            Content = template.Content,
+            IsActive = template.IsActive
+        };
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        EmailTemplate? template = await _emailTemplateManager.GetAsync(Id);
+        if (template == null)
+        {
+            return RedirectToPage("Index");
+        }
+
+        // Check if a template with this location already exists (if location changed)
+        if (template.Location != Input.Location)
+        {
+            EmailTemplate? existing = await _emailTemplateManager.GetByLocationAsync(Input.Location);
+            if (existing != null)
+            {
+                ModelState.AddModelError("Input.Location", "An email template with this location already exists.");
+                return Page();
+            }
+        }
+
+        template.Location = Input.Location.Trim();
+        template.Content = Input.Content;
+        template.IsActive = Input.IsActive;
+
+        await _emailTemplateManager.SaveAsync(template);
+        _logger.LogInformation("[Admin:EmailTemplates] Updated email template {Id} {Location}", template.Id, template.Location);
+
+        return RedirectToPage("Index");
+    }
+}

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Index.cshtml
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Index.cshtml
@@ -1,0 +1,109 @@
+@page
+@using MoreSpeakers.Domain.Models.AdminUsers
+@model MoreSpeakers.Web.Areas.Admin.Pages.Catalog.EmailTemplates.IndexModel
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+@{
+    ViewData["Title"] = "Email Templates";
+}
+
+<h1 class="mb-4">Email Templates</h1>
+
+<nav aria-label="breadcrumb" class="mb-3">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a asp-area="Admin" asp-page="/Index">Admin</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Email Templates</li>
+  </ol>
+</nav>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <form method="get" class="row g-2 align-items-center">
+        <div class="col-auto">
+            <div class="input-group">
+                <span class="input-group-text"><i class="bi bi-search"></i></span>
+                <input name="q" id="q" class="form-control" placeholder="Search by location…"
+                       value="@Model.Q" />
+            </div>
+        </div>
+        <div class="col-auto">
+            <select class="form-select" name="status" aria-label="Filter by status">
+                <option value="any" selected="@(Model.Status == TriState.Any)">Any status</option>
+                <option value="active" selected="@(Model.Status == TriState.True)">Active</option>
+                <option value="inactive" selected="@(Model.Status == TriState.False)">Inactive</option>
+            </select>
+        </div>
+        <div class="col-auto">
+            <button class="btn btn-outline-secondary" type="submit">Filter</button>
+        </div>
+    </form>
+
+    <a class="btn btn-primary" asp-page="Create"><i class="bi bi-plus-lg me-1"></i>New Email Template</a>
+</div>
+
+<div class="table-responsive">
+    <table class="table table-striped align-middle">
+        <thead>
+            <tr>
+                <th>Location</th>
+                <th>Status</th>
+                <th>Last Modified</th>
+                <th class="text-end" style="width: 220px">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        @if (!Model.Items.Any())
+        {
+            <tr>
+                <td colspan="4" class="text-muted">No email templates found.</td>
+            </tr>
+        }
+        else
+        {
+            foreach (var item in Model.Items)
+            {
+                <tr class="@(item.IsActive ? string.Empty : "table-secondary")">
+                    <td><code>@item.Location</code></td>
+                    <td>
+                        @if (item.IsActive)
+                        {
+                            <span class="badge bg-success">Active</span>
+                        }
+                        else
+                        {
+                            <span class="badge bg-secondary">Inactive</span>
+                        }
+                    </td>
+                    <td>@item.LastModified.ToString("g")</td>
+                    <td class="text-end">
+                        <a class="btn btn-sm btn-outline-info" asp-page="Details" asp-route-id="@item.Id" title="Details">
+                            <i class="bi bi-info-circle"></i>
+                        </a>
+                        <a class="btn btn-sm btn-outline-primary" asp-page="Edit" asp-route-id="@item.Id" title="Edit">
+                            <i class="bi bi-pencil"></i>
+                        </a>
+                        @if (item.IsActive)
+                        {
+                            <form method="post" asp-page-handler="Deactivate" asp-route-id="@item.Id" asp-route-q="@Model.Q" asp-route-status="@Model.Status" class="d-inline">
+                                <button type="submit" class="btn btn-sm btn-outline-warning" title="Deactivate">
+                                    <i class="bi bi-archive"></i>
+                                </button>
+                            </form>
+                        }
+                        else
+                        {
+                            <form method="post" asp-page-handler="Activate" asp-route-id="@item.Id" asp-route-q="@Model.Q" asp-route-status="@Model.Status" class="d-inline">
+                                <button type="submit" class="btn btn-sm btn-outline-success" title="Activate">
+                                    <i class="bi bi-arrow-counterclockwise"></i>
+                                </button>
+                            </form>
+                        }
+                        <a class="btn btn-sm btn-outline-danger" asp-page="Delete" asp-route-id="@item.Id" title="Delete">
+                            <i class="bi bi-trash3"></i>
+                        </a>
+                    </td>
+                </tr>
+            }
+        }
+        </tbody>
+    </table>
+</div>

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Index.cshtml.cs
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Catalog/EmailTemplates/Index.cshtml.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using MoreSpeakers.Domain.Interfaces;
+using MoreSpeakers.Domain.Models;
+using MoreSpeakers.Domain.Models.AdminUsers;
+
+namespace MoreSpeakers.Web.Areas.Admin.Pages.Catalog.EmailTemplates;
+
+public class IndexModel(IEmailTemplateManager emailTemplateManager, ILogger<IndexModel> logger) : PageModel
+{
+    private readonly IEmailTemplateManager _emailTemplateManager = emailTemplateManager;
+    private readonly ILogger<IndexModel> _logger = logger;
+
+    public List<EmailTemplate> Items { get; private set; } = new();
+
+    [BindProperty(SupportsGet = true)]
+    public string? Q { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public TriState Status { get; set; } = TriState.Any;
+
+    public async Task OnGetAsync()
+    {
+        Items = await _emailTemplateManager.GetAllTemplatesAsync(Status, Q);
+    }
+
+    public async Task<IActionResult> OnPostDeactivateAsync(int id)
+    {
+        EmailTemplate? template = await _emailTemplateManager.GetAsync(id);
+        if (template is null)
+        {
+            return RedirectToPage();
+        }
+
+        if (!template.IsActive)
+        {
+            return RedirectToPage(new { q = Q, status = Status });
+        }
+
+        template.IsActive = false;
+        await _emailTemplateManager.SaveAsync(template);
+        _logger.LogInformation("[Admin:EmailTemplates] Deactivated email template {Id} {Location}", template.Id, template.Location);
+        return RedirectToPage(new { q = Q, status = Status });
+    }
+
+    public async Task<IActionResult> OnPostActivateAsync(int id)
+    {
+        EmailTemplate? template = await _emailTemplateManager.GetAsync(id);
+        if (template is null)
+        {
+            return RedirectToPage();
+        }
+
+        if (template.IsActive)
+        {
+            return RedirectToPage(new { q = Q, status = Status });
+        }
+
+        template.IsActive = true;
+        await _emailTemplateManager.SaveAsync(template);
+        _logger.LogInformation("[Admin:EmailTemplates] Activated email template {Id} {Location}", template.Id, template.Location);
+        return RedirectToPage(new { q = Q, status = Status });
+    }
+}

--- a/src/MoreSpeakers.Web/Areas/Admin/Pages/Index.cshtml
+++ b/src/MoreSpeakers.Web/Areas/Admin/Pages/Index.cshtml
@@ -26,6 +26,7 @@
       {
           new DashboardTile("Manage Users", "Accounts, roles, and access.", "bi bi-people", "Admin", "/Users/Index"),
           new DashboardTile("Social Sites", "Edit social platforms and URL formats.", "bi bi-share", "Admin", "/Catalog/SocialSites/Index"),
+          new DashboardTile("Email Templates", "Manage email templates.", "bi bi-envelope", "Admin", "/Catalog/EmailTemplates/Index"),
           new DashboardTile("Expertise / Sectors", "Organize domains and specializations.", "bi bi-diagram-3", "Admin", "/Catalog/Expertises/Sectors/Index"),
           new DashboardTile("Expertise / Categories", "Organize the expertise categories.", "bi bi-diagram-3", "Admin", "/Catalog/Expertises/Categories/Index"),
           new DashboardTile("Expertise / Expertises", "Organize the expertise.", "bi bi-diagram-3", "Admin", "/Catalog/Expertises/Expertises/Index"),


### PR DESCRIPTION
### Description of the Change

This pull request enhances the email template functionality by introducing several improvements:
- Refactors email templates to use `Id` as the primary key, replacing `Location`.
- Adds a new `GetByLocationAsync` method for retrieving templates by location.
- Updates `DbContext` with stricter configuration and unique constraint enforcement on `Location`.
- Improves the management layer (`EmailTemplateManager` and `EmailTemplateDataStore`) for handling CRUD operations.
- Includes a new admin UI for creating, editing, and viewing email templates.
- Augments unit tests to cover template retrieval and validation workflows.
- Modifies seed data to include `Id` where applicable.

### Benefits

- Simplifies email template management via a well-structured approach using `Id`.
- Ensures data consistency and prevents duplication by adding stricter constraints.
- Provides administrators with an accessible user interface to manage templates more efficiently.
- Improves system reliability through expanded test coverage.

### Verification Process

- Verified unit tests for new and modified methods.
- Confirmed proper integration of UI components for template management.
- Tested CRUD operations for email templates to ensure compatibility.

### Applicable Issues

Refs #356
```