### PR TITLE
feat(domain): add Result<T> and Error foundation types for exception handling

### DIFF
--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -12,7 +12,11 @@
 ## Recent Updates
 
 - 2026-04-13: Team initialized with the Alien cast.
+- 2026-04-15: Phase 1 Result foundation complete; types added to Domain, mirroring IdentityResult factory pattern. Public namespace export via GlobalUsings. Ready for Phase 2 PoC (#386).
+- 2026-04-15: Orchestration log archived. Inbox decisions merged to decisions.md. Session log written. User directives captured (exception standardization, branch naming).
 
 ## Learnings
 
 - This project includes both an ASP.NET Razor Pages application and an Azure Functions project.
+- 2026-04-15: Phase 1 Result foundation lives in `src\MoreSpeakers.Domain\Models\Error.cs` and `src\MoreSpeakers.Domain\Models\Result.cs`, with coverage in `src\MoreSpeakers.Domain.Tests\ResultTests.cs`.
+- 2026-04-15: The Result pattern here keeps creation on static `Result` factory methods to mirror `IdentityResult`, while `Result<T>` adds implicit value conversion and explicit failure accessors.

--- a/.squad/agents/vasquez/history.md
+++ b/.squad/agents/vasquez/history.md
@@ -12,7 +12,11 @@
 ## Recent Updates
 
 - 2026-04-13: Team initialized with the Alien cast.
+- 2026-04-15: Contract-first test suite completed for Issue #385 foundation. Reflection-based tests allow compilation before domain types exist. Full coverage: Result, Result<T>, Error types, factory methods, implicit conversions, equality. Tests serve as contract gate for implementation.
+- 2026-04-15: Orchestration log archived. Inbox decisions merged to decisions.md. Session log written. User directives captured (exception standardization, branch naming).
 
 ## Learnings
 
 - The existing testing toolbox is xUnit, FluentAssertions, Moq, and Bogus.
+- Issue #385 contract coverage lives in `src/MoreSpeakers.Domain.Tests\ResultFoundationTests.cs` and uses reflection against `MoreSpeakers.Domain` so tests compile before `Result`, `Result<T>`, and `Error` exist.
+- Reflection-based contract tests allow test-first iteration on large surface area without blocking on compile gates.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -89,6 +89,20 @@ Updated README.md to reflect .NET 10, EF Core 10 (runtime ORM), actual project s
 **Labels:** `squad:dallas`, `squad:bishop`, `squad:vasquez` applied to all issues.  
 **Result:** Squad members unblocked to begin work.
 
+## Work Directives (2026-04-15)
+
+### User Directive: Continue Exception Standardization
+
+**Status:** Active | **Owner:** Squad  
+**What:** Continue standardizing exception handling as an active team decision.  
+**Why:** User request — aligns with Result<T> adoption across backlog (#385–#394).
+
+### User Directive: Git Branch Naming
+
+**Status:** Active | **Owner:** Squad  
+**What:** For issue work, use git branches named as `issue-number-brief-description`.  
+**Why:** User request — improves traceability and branch hygiene.
+
 ## Governance
 
 - All meaningful changes require team consensus

--- a/.squad/skills/reflection-contract-tests/SKILL.md
+++ b/.squad/skills/reflection-contract-tests/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: "reflection-contract-tests"
+description: "Use reflection-based tests to lock an API contract before the implementation lands."
+domain: "testing"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+Use this when a team wants tests merged ahead of an additive implementation. The goal is to keep the test project compiling while still failing loudly if required public types or members are missing.
+
+## Patterns
+- Load the target assembly from an existing known type instead of referencing the new contract directly.
+- Assert on public type names, namespace, shape, factory methods, operators, and property values through reflection.
+- Fail with explicit messages that name the missing type or member so the implementer gets a clean failure story.
+
+## Examples
+- `src/MoreSpeakers.Domain.Tests\ResultFoundationTests.cs` validates the future `MoreSpeakers.Domain.Result`, `MoreSpeakers.Domain.Result<T>`, and `MoreSpeakers.Domain.Error` contract before those types exist.
+
+## Anti-Patterns
+- Do not use reflection when the implementation already exists and compile-time assertions are simpler.
+- Do not make reflection tests so vague that multiple incompatible APIs would pass.

--- a/.squad/skills/result-foundation/SKILL.md
+++ b/.squad/skills/result-foundation/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: "result-foundation"
+description: "Add or extend MoreSpeakers Domain Result types with explicit factory methods and structured errors."
+domain: "error-handling"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+Use this skill when implementing or extending the approved Result-based exception handling migration in the Domain layer. It applies when expected failures need to flow through Data, Managers, and Web without losing structured context.
+
+## Patterns
+- Keep `Error`, `Result`, and `Result<T>` in `src\MoreSpeakers.Domain\Models\`, but expose them from the root `MoreSpeakers.Domain` namespace.
+- Model creation after `IdentityResult`: factory methods live on non-generic `Result` instead of exposing public constructors.
+- Use `readonly struct` for `Result` and `Result<T>` to stay additive and allocation-conscious on the hot path.
+- Keep failure access explicit: success results throw if callers read `Error`, and failure results throw if callers read `Value`.
+- Cover the public API surface in `src\MoreSpeakers.Domain.Tests\ResultTests.cs`, including success, failure, implicit conversion, and equality.
+
+## Examples
+- `var ok = Result.Success();`
+- `var saved = Result.Success(user);`
+- `var failed = Result.Failure<User>(new Error("users.save.failed", "Unable to save the user.", ex));`
+- `Result<Guid> id = Guid.NewGuid();`
+
+## Anti-Patterns
+- Do not expose public constructors for `Result` or `Result<T>`.
+- Do not use sentinel values (`null`, `false`, empty collections) for expected failures once a Result-based path exists.
+- Do not strip exception context when an `Error` can carry the underlying exception reference.

--- a/src/MoreSpeakers.Domain.Tests/MoreSpeakers.Domain.Tests.csproj
+++ b/src/MoreSpeakers.Domain.Tests/MoreSpeakers.Domain.Tests.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit.v3" Version="3.2.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/MoreSpeakers.Domain.Tests/ResultFoundationTests.cs
+++ b/src/MoreSpeakers.Domain.Tests/ResultFoundationTests.cs
@@ -1,0 +1,310 @@
+using System.Reflection;
+
+using FluentAssertions;
+
+using MoreSpeakers.Domain.Models;
+
+namespace MoreSpeakers.Domain.Tests;
+
+public class ResultFoundationTests
+{
+    private const string ResultTypeName = "MoreSpeakers.Domain.Result";
+    private const string GenericResultTypeName = "MoreSpeakers.Domain.Result`1";
+    private const string ErrorTypeName = "MoreSpeakers.Domain.Error";
+    private static readonly Assembly DomainAssembly = typeof(User).Assembly;
+
+    [Fact]
+    public void Foundation_contract_types_should_be_public_and_rooted_in_domain_namespace()
+    {
+        var resultType = GetResultType();
+        var genericResultType = GetGenericResultType();
+        var errorType = GetErrorType();
+
+        resultType.IsPublic.Should().BeTrue();
+        resultType.IsValueType.Should().BeTrue();
+        resultType.Namespace.Should().Be("MoreSpeakers.Domain");
+
+        genericResultType.IsPublic.Should().BeTrue();
+        genericResultType.IsValueType.Should().BeTrue();
+        genericResultType.IsGenericTypeDefinition.Should().BeTrue();
+        genericResultType.GetGenericArguments().Should().ContainSingle();
+        genericResultType.Namespace.Should().Be("MoreSpeakers.Domain");
+
+        errorType.IsPublic.Should().BeTrue();
+        errorType.Namespace.Should().Be("MoreSpeakers.Domain");
+    }
+
+    [Fact]
+    public void Error_should_expose_code_message_and_exception_context()
+    {
+        var exception = new InvalidOperationException("boom");
+        var error = CreateError("result.failure", "Something went wrong.", exception);
+
+        GetPropertyValue<string>(error, "Code").Should().Be("result.failure");
+        GetPropertyValue<string>(error, "Message").Should().Be("Something went wrong.");
+        GetExceptionProperty(error.GetType()).GetValue(error).Should().BeSameAs(exception);
+    }
+
+    [Fact]
+    public void Error_should_use_value_equality()
+    {
+        var first = CreateError("duplicate", "Already exists.", null);
+        var second = CreateError("duplicate", "Already exists.", null);
+        var third = CreateError("unexpected", "Something else failed.", null);
+
+        first.Should().Be(second);
+        first.GetHashCode().Should().Be(second.GetHashCode());
+        first.Should().NotBe(third);
+    }
+
+    [Fact]
+    public void Result_public_api_should_match_the_foundation_contract()
+    {
+        var resultType = GetResultType();
+        var genericResultType = GetGenericResultType();
+        var errorType = GetErrorType();
+
+        GetRequiredProperty(resultType, "IsSuccess").PropertyType.Should().Be(typeof(bool));
+        GetRequiredProperty(resultType, "IsFailure").PropertyType.Should().Be(typeof(bool));
+        GetRequiredProperty(resultType, "Error").PropertyType.Should().Be(errorType);
+
+        GetRequiredProperty(genericResultType.MakeGenericType(typeof(string)), "IsSuccess").PropertyType.Should().Be(typeof(bool));
+        GetRequiredProperty(genericResultType.MakeGenericType(typeof(string)), "IsFailure").PropertyType.Should().Be(typeof(bool));
+        GetRequiredProperty(genericResultType.MakeGenericType(typeof(string)), "Error").PropertyType.Should().Be(errorType);
+        GetRequiredProperty(genericResultType.MakeGenericType(typeof(string)), "Value").PropertyType.Should().Be(typeof(string));
+
+        GetStaticMethod(resultType, "Success", false, Type.EmptyTypes).ReturnType.Should().Be(resultType);
+        GetGenericFactoryMethod(resultType, "Success", parameter => parameter.ParameterType.IsGenericParameter)
+            .MakeGenericMethod(typeof(string))
+            .ReturnType.Should().Be(genericResultType.MakeGenericType(typeof(string)));
+        GetStaticMethod(resultType, "Failure", false, errorType).ReturnType.Should().Be(resultType);
+        GetGenericFactoryMethod(resultType, "Failure", parameter => parameter.ParameterType == errorType)
+            .MakeGenericMethod(typeof(string))
+            .ReturnType.Should().Be(genericResultType.MakeGenericType(typeof(string)));
+    }
+
+    [Fact]
+    public void Result_success_factory_should_create_a_successful_void_result()
+    {
+        var result = InvokeSuccessFactory();
+
+        GetPropertyValue<bool>(result, "IsSuccess").Should().BeTrue();
+        GetPropertyValue<bool>(result, "IsFailure").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Result_failure_factory_should_capture_the_error()
+    {
+        var error = CreateError("result.failure", "Nope.", null);
+        var result = InvokeFailureFactory(error);
+
+        GetPropertyValue<bool>(result, "IsSuccess").Should().BeFalse();
+        GetPropertyValue<bool>(result, "IsFailure").Should().BeTrue();
+        GetPropertyValue<object>(result, "Error").Should().Be(error);
+    }
+
+    [Fact]
+    public void Result_of_t_success_factory_should_capture_the_value()
+    {
+        var result = InvokeGenericSuccessFactory(typeof(string), "ok");
+
+        GetPropertyValue<bool>(result, "IsSuccess").Should().BeTrue();
+        GetPropertyValue<bool>(result, "IsFailure").Should().BeFalse();
+        GetPropertyValue<string>(result, "Value").Should().Be("ok");
+    }
+
+    [Fact]
+    public void Result_of_t_failure_factory_should_capture_the_error()
+    {
+        var error = CreateError("result.failure", "Still nope.", null);
+        var result = InvokeGenericFailureFactory(typeof(string), error);
+
+        GetPropertyValue<bool>(result, "IsSuccess").Should().BeFalse();
+        GetPropertyValue<bool>(result, "IsFailure").Should().BeTrue();
+        GetPropertyValue<object>(result, "Error").Should().Be(error);
+    }
+
+    [Fact]
+    public void Result_should_support_implicit_failure_conversion_from_error()
+    {
+        var error = CreateError("implicit.failure", "Converted from error.", null);
+        var converted = InvokeImplicitOperator(GetResultType(), GetErrorType(), error);
+
+        GetPropertyValue<bool>(converted, "IsSuccess").Should().BeFalse();
+        GetPropertyValue<bool>(converted, "IsFailure").Should().BeTrue();
+        GetPropertyValue<object>(converted, "Error").Should().Be(error);
+    }
+
+    [Fact]
+    public void Result_of_t_should_support_implicit_success_and_failure_conversions()
+    {
+        var closedGenericResult = GetGenericResultType().MakeGenericType(typeof(string));
+        var success = InvokeImplicitOperator(closedGenericResult, typeof(string), "done");
+        var error = CreateError("implicit.failure", "Generic conversion failed.", null);
+        var failure = InvokeImplicitOperator(closedGenericResult, GetErrorType(), error);
+
+        GetPropertyValue<bool>(success, "IsSuccess").Should().BeTrue();
+        GetPropertyValue<string>(success, "Value").Should().Be("done");
+        GetPropertyValue<bool>(failure, "IsFailure").Should().BeTrue();
+        GetPropertyValue<object>(failure, "Error").Should().Be(error);
+    }
+
+    [Fact]
+    public void Result_should_use_value_equality()
+    {
+        var error = CreateError("same.error", "Same failure.", null);
+        var success = InvokeSuccessFactory();
+        var otherSuccess = InvokeSuccessFactory();
+        var failure = InvokeFailureFactory(error);
+        var otherFailure = InvokeFailureFactory(error);
+
+        success.Should().Be(otherSuccess);
+        success.GetHashCode().Should().Be(otherSuccess.GetHashCode());
+        failure.Should().Be(otherFailure);
+        failure.GetHashCode().Should().Be(otherFailure.GetHashCode());
+        success.Should().NotBe(failure);
+    }
+
+    [Fact]
+    public void Result_of_t_should_use_value_equality()
+    {
+        var error = CreateError("same.error", "Same failure.", null);
+        var success = InvokeGenericSuccessFactory(typeof(int), 42);
+        var otherSuccess = InvokeGenericSuccessFactory(typeof(int), 42);
+        var failure = InvokeGenericFailureFactory(typeof(int), error);
+        var otherFailure = InvokeGenericFailureFactory(typeof(int), error);
+
+        success.Should().Be(otherSuccess);
+        success.GetHashCode().Should().Be(otherSuccess.GetHashCode());
+        failure.Should().Be(otherFailure);
+        failure.GetHashCode().Should().Be(otherFailure.GetHashCode());
+        success.Should().NotBe(failure);
+    }
+
+    private static Type GetResultType()
+    {
+        var type = DomainAssembly.GetType(ResultTypeName);
+        type.Should().NotBeNull($"the {ResultTypeName} foundation type should exist in MoreSpeakers.Domain");
+        return type!;
+    }
+
+    private static Type GetGenericResultType()
+    {
+        var type = DomainAssembly.GetType(GenericResultTypeName);
+        type.Should().NotBeNull($"the {GenericResultTypeName} foundation type should exist in MoreSpeakers.Domain");
+        return type!;
+    }
+
+    private static Type GetErrorType()
+    {
+        var type = DomainAssembly.GetType(ErrorTypeName);
+        type.Should().NotBeNull($"the {ErrorTypeName} foundation type should exist in MoreSpeakers.Domain");
+        return type!;
+    }
+
+    private static object CreateError(string code, string message, Exception? exception)
+    {
+        var errorType = GetErrorType();
+        var constructor = errorType.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .SingleOrDefault(candidate =>
+            {
+                var parameters = candidate.GetParameters();
+                return parameters.Length == 3
+                       && parameters[0].ParameterType == typeof(string)
+                       && parameters[1].ParameterType == typeof(string)
+                       && typeof(Exception).IsAssignableFrom(parameters[2].ParameterType);
+            });
+
+        constructor.Should().NotBeNull("Error should expose a public constructor accepting code, message, and an optional exception");
+
+        return constructor!.Invoke(new object?[] { code, message, exception });
+    }
+
+    private static object InvokeSuccessFactory()
+        => GetStaticMethod(GetResultType(), "Success", false, Type.EmptyTypes).Invoke(null, null)!;
+
+    private static object InvokeFailureFactory(object error)
+        => GetStaticMethod(GetResultType(), "Failure", false, GetErrorType()).Invoke(null, new[] { error })!;
+
+    private static object InvokeGenericSuccessFactory(Type valueType, object value)
+        => GetGenericFactoryMethod(GetResultType(), "Success", parameter => parameter.ParameterType.IsGenericParameter)
+            .MakeGenericMethod(valueType)
+            .Invoke(null, new[] { value })!;
+
+    private static object InvokeGenericFailureFactory(Type valueType, object error)
+        => GetGenericFactoryMethod(GetResultType(), "Failure", parameter => parameter.ParameterType == GetErrorType())
+            .MakeGenericMethod(valueType)
+            .Invoke(null, new[] { error })!;
+
+    private static object InvokeImplicitOperator(Type targetType, Type parameterType, object value)
+    {
+        var method = targetType.GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .SingleOrDefault(candidate =>
+            {
+                var parameters = candidate.GetParameters();
+                return candidate.Name == "op_Implicit"
+                       && candidate.ReturnType == targetType
+                       && parameters.Length == 1
+                       && parameters[0].ParameterType == parameterType;
+            });
+
+        method.Should().NotBeNull($"expected {targetType} to declare an implicit conversion from {parameterType}");
+
+        return method!.Invoke(null, new[] { value })!;
+    }
+
+    private static MethodInfo GetStaticMethod(Type declaringType, string name, bool isGenericMethodDefinition, params Type[] parameterTypes)
+    {
+        var method = declaringType.GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .SingleOrDefault(candidate =>
+            {
+                var parameters = candidate.GetParameters();
+                return candidate.Name == name
+                       && candidate.IsGenericMethodDefinition == isGenericMethodDefinition
+                       && parameters.Length == parameterTypes.Length
+                       && parameters.Zip(parameterTypes).All(pair => pair.First.ParameterType == pair.Second);
+            });
+
+        method.Should().NotBeNull($"expected {declaringType} to declare {name}({string.Join(", ", parameterTypes.Select(type => type.Name))})");
+
+        return method!;
+    }
+
+    private static MethodInfo GetGenericFactoryMethod(Type declaringType, string name, Func<ParameterInfo, bool> parameterMatcher)
+    {
+        var method = declaringType.GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .SingleOrDefault(candidate =>
+            {
+                var parameters = candidate.GetParameters();
+                return candidate.Name == name
+                       && candidate.IsGenericMethodDefinition
+                       && candidate.GetGenericArguments().Length == 1
+                       && parameters.Length == 1
+                       && parameterMatcher(parameters[0]);
+            });
+
+        method.Should().NotBeNull($"expected {declaringType} to declare a generic {name} factory");
+
+        return method!;
+    }
+
+    private static PropertyInfo GetRequiredProperty(Type declaringType, string propertyName)
+    {
+        var property = declaringType.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
+        property.Should().NotBeNull($"expected {declaringType} to expose a public {propertyName} property");
+        return property!;
+    }
+
+    private static PropertyInfo GetExceptionProperty(Type declaringType)
+    {
+        var property = declaringType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .SingleOrDefault(candidate => typeof(Exception).IsAssignableFrom(candidate.PropertyType));
+
+        property.Should().NotBeNull("Error should expose a public exception property for optional diagnostic context");
+
+        return property!;
+    }
+
+    private static T GetPropertyValue<T>(object instance, string propertyName)
+        => (T)GetRequiredProperty(instance.GetType(), propertyName).GetValue(instance)!;
+}

--- a/src/MoreSpeakers.Domain.Tests/ResultTests.cs
+++ b/src/MoreSpeakers.Domain.Tests/ResultTests.cs
@@ -1,0 +1,103 @@
+using MoreSpeakers.Domain;
+
+namespace MoreSpeakers.Domain.Tests;
+
+public class ResultTests
+{
+    [Fact]
+    public void Error_stores_code_message_and_exception()
+    {
+        var exception = new InvalidOperationException("boom");
+
+        var error = new Error("users.save.failed", "Unable to save the user.", exception);
+
+        Assert.Equal("users.save.failed", error.Code);
+        Assert.Equal("Unable to save the user.", error.Message);
+        Assert.Same(exception, error.Exception);
+    }
+
+    [Fact]
+    public void Success_without_value_creates_successful_result()
+    {
+        var result = Result.Success();
+
+        Assert.True(result.IsSuccess);
+        Assert.False(result.IsFailure);
+        Assert.Throws<InvalidOperationException>(() => _ = result.Error);
+    }
+
+    [Fact]
+    public void Failure_without_value_creates_failed_result()
+    {
+        var error = new Error("users.save.failed", "Unable to save the user.");
+
+        var result = Result.Failure(error);
+
+        Assert.False(result.IsSuccess);
+        Assert.True(result.IsFailure);
+        Assert.Equal(error, result.Error);
+    }
+
+    [Fact]
+    public void Success_with_value_creates_successful_generic_result()
+    {
+        var result = Result.Success("speaker");
+
+        Assert.True(result.IsSuccess);
+        Assert.False(result.IsFailure);
+        Assert.Equal("speaker", result.Value);
+        Assert.Throws<InvalidOperationException>(() => _ = result.Error);
+    }
+
+    [Fact]
+    public void Failure_with_value_type_parameter_creates_failed_generic_result()
+    {
+        var error = new Error("users.find.failed", "Unable to find the user.");
+
+        var result = Result.Failure<string>(error);
+
+        Assert.False(result.IsSuccess);
+        Assert.True(result.IsFailure);
+        Assert.Equal(error, result.Error);
+        Assert.Throws<InvalidOperationException>(() => _ = result.Value);
+    }
+
+    [Fact]
+    public void Implicit_conversion_wraps_value_in_successful_result()
+    {
+        Result<int> result = 42;
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void Implicit_error_conversion_wraps_failure_results()
+    {
+        Error error = new("users.delete.failed", "Unable to delete the user.");
+
+        Result result = error;
+        Result<string> genericResult = error;
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(error, result.Error);
+        Assert.True(genericResult.IsFailure);
+        Assert.Equal(error, genericResult.Error);
+    }
+
+    [Fact]
+    public void Results_support_value_equality()
+    {
+        var error = new Error("users.delete.failed", "Unable to delete the user.");
+
+        var left = Result.Success("speaker");
+        Result<string> right = "speaker";
+        var failedLeft = Result.Failure(error);
+        var failedRight = Result.Failure(new Error("users.delete.failed", "Unable to delete the user."));
+
+        Assert.Equal(left, right);
+        Assert.True(left == right);
+        Assert.Equal(failedLeft, failedRight);
+        Assert.True(failedLeft == failedRight);
+    }
+}

--- a/src/MoreSpeakers.Domain/Models/Error.cs
+++ b/src/MoreSpeakers.Domain/Models/Error.cs
@@ -1,0 +1,48 @@
+namespace MoreSpeakers.Domain;
+
+/// <summary>
+/// Represents a structured error for an expected failure.
+/// </summary>
+public sealed record Error
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Error"/> record.
+    /// </summary>
+    /// <param name="code">The machine-readable error code.</param>
+    /// <param name="message">The human-readable error message.</param>
+    /// <param name="exception">The optional underlying exception.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="code"/> or <paramref name="message"/> is empty.
+    /// </exception>
+    public Error(string code, string message, Exception? exception = null)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            throw new ArgumentException("An error code is required.", nameof(code));
+        }
+
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            throw new ArgumentException("An error message is required.", nameof(message));
+        }
+
+        Code = code;
+        Message = message;
+        Exception = exception;
+    }
+
+    /// <summary>
+    /// Gets the machine-readable error code.
+    /// </summary>
+    public string Code { get; init; }
+
+    /// <summary>
+    /// Gets the human-readable error message.
+    /// </summary>
+    public string Message { get; init; }
+
+    /// <summary>
+    /// Gets the optional underlying exception.
+    /// </summary>
+    public Exception? Exception { get; init; }
+}

--- a/src/MoreSpeakers.Domain/Models/Result.cs
+++ b/src/MoreSpeakers.Domain/Models/Result.cs
@@ -1,0 +1,221 @@
+using System.Collections.Generic;
+
+namespace MoreSpeakers.Domain;
+
+/// <summary>
+/// Represents the outcome of an operation that does not return a value.
+/// </summary>
+public readonly struct Result : IEquatable<Result>
+{
+    private readonly Error? _error;
+
+    private Result(bool isSuccess, Error? error)
+    {
+        if (isSuccess && error is not null)
+        {
+            throw new ArgumentException("A successful result cannot contain an error.", nameof(error));
+        }
+
+        if (!isSuccess && error is null)
+        {
+            throw new ArgumentNullException(nameof(error), "A failed result must contain an error.");
+        }
+
+        IsSuccess = isSuccess;
+        _error = error;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the operation succeeded.
+    /// </summary>
+    public bool IsSuccess { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the operation failed.
+    /// </summary>
+    public bool IsFailure => !IsSuccess;
+
+    /// <summary>
+    /// Gets the error that describes the failure.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when the result is successful.</exception>
+    public Error Error => IsFailure
+        ? _error!
+        : throw new InvalidOperationException("A successful result does not contain an error.");
+
+    /// <summary>
+    /// Creates a successful result without a value.
+    /// </summary>
+    /// <returns>A successful <see cref="Result"/>.</returns>
+    public static Result Success() => new(true, null);
+
+    /// <summary>
+    /// Creates a successful result with a value.
+    /// </summary>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <param name="value">The value to wrap.</param>
+    /// <returns>A successful <see cref="Result{T}"/>.</returns>
+    public static Result<T> Success<T>(T value) => new(value);
+
+    /// <summary>
+    /// Creates a failed result.
+    /// </summary>
+    /// <param name="error">The error that describes the failure.</param>
+    /// <returns>A failed <see cref="Result"/>.</returns>
+    public static Result Failure(Error error) => new(false, error);
+
+    /// <summary>
+    /// Creates a failed result with a value type parameter.
+    /// </summary>
+    /// <typeparam name="T">The type of the value that would have been returned on success.</typeparam>
+    /// <param name="error">The error that describes the failure.</param>
+    /// <returns>A failed <see cref="Result{T}"/>.</returns>
+    public static Result<T> Failure<T>(Error error) => new(error);
+
+    /// <summary>
+    /// Converts an error to a failed result.
+    /// </summary>
+    /// <param name="error">The error to wrap.</param>
+    public static implicit operator Result(Error error) => Failure(error);
+
+    /// <summary>
+    /// Indicates whether the current result is equal to another result.
+    /// </summary>
+    /// <param name="other">The result to compare with the current result.</param>
+    /// <returns><see langword="true"/> when the results are equal; otherwise, <see langword="false"/>.</returns>
+    public bool Equals(Result other) =>
+        IsSuccess == other.IsSuccess &&
+        EqualityComparer<Error?>.Default.Equals(_error, other._error);
+
+    /// <summary>
+    /// Indicates whether the current result is equal to a specified object.
+    /// </summary>
+    /// <param name="obj">The object to compare with the current result.</param>
+    /// <returns><see langword="true"/> when the object is a matching result; otherwise, <see langword="false"/>.</returns>
+    public override bool Equals(object? obj) => obj is Result other && Equals(other);
+
+    /// <summary>
+    /// Returns the hash code for this result.
+    /// </summary>
+    /// <returns>A hash code for this result.</returns>
+    public override int GetHashCode() => HashCode.Combine(IsSuccess, _error);
+
+    /// <summary>
+    /// Determines whether two results are equal.
+    /// </summary>
+    /// <param name="left">The left result.</param>
+    /// <param name="right">The right result.</param>
+    /// <returns><see langword="true"/> when the results are equal; otherwise, <see langword="false"/>.</returns>
+    public static bool operator ==(Result left, Result right) => left.Equals(right);
+
+    /// <summary>
+    /// Determines whether two results are not equal.
+    /// </summary>
+    /// <param name="left">The left result.</param>
+    /// <param name="right">The right result.</param>
+    /// <returns><see langword="true"/> when the results differ; otherwise, <see langword="false"/>.</returns>
+    public static bool operator !=(Result left, Result right) => !left.Equals(right);
+}
+
+/// <summary>
+/// Represents the outcome of an operation that returns a value.
+/// </summary>
+/// <typeparam name="T">The type of the wrapped value.</typeparam>
+public readonly struct Result<T> : IEquatable<Result<T>>
+{
+    private readonly T? _value;
+    private readonly Error? _error;
+
+    internal Result(T value)
+    {
+        IsSuccess = true;
+        _value = value;
+        _error = null;
+    }
+
+    internal Result(Error error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+
+        IsSuccess = false;
+        _value = default;
+        _error = error;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the operation succeeded.
+    /// </summary>
+    public bool IsSuccess { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the operation failed.
+    /// </summary>
+    public bool IsFailure => !IsSuccess;
+
+    /// <summary>
+    /// Gets the successful value.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when the result is a failure.</exception>
+    public T Value => IsSuccess
+        ? _value!
+        : throw new InvalidOperationException("A failed result does not contain a value.");
+
+    /// <summary>
+    /// Gets the error that describes the failure.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when the result is successful.</exception>
+    public Error Error => IsFailure
+        ? _error!
+        : throw new InvalidOperationException("A successful result does not contain an error.");
+
+    /// <summary>
+    /// Converts a value to a successful result.
+    /// </summary>
+    /// <param name="value">The value to wrap.</param>
+    public static implicit operator Result<T>(T value) => Result.Success(value);
+
+    /// <summary>
+    /// Converts an error to a failed result.
+    /// </summary>
+    /// <param name="error">The error to wrap.</param>
+    public static implicit operator Result<T>(Error error) => Result.Failure<T>(error);
+
+    /// <summary>
+    /// Indicates whether the current result is equal to another result.
+    /// </summary>
+    /// <param name="other">The result to compare with the current result.</param>
+    /// <returns><see langword="true"/> when the results are equal; otherwise, <see langword="false"/>.</returns>
+    public bool Equals(Result<T> other) =>
+        IsSuccess == other.IsSuccess &&
+        EqualityComparer<T?>.Default.Equals(_value, other._value) &&
+        EqualityComparer<Error?>.Default.Equals(_error, other._error);
+
+    /// <summary>
+    /// Indicates whether the current result is equal to a specified object.
+    /// </summary>
+    /// <param name="obj">The object to compare with the current result.</param>
+    /// <returns><see langword="true"/> when the object is a matching result; otherwise, <see langword="false"/>.</returns>
+    public override bool Equals(object? obj) => obj is Result<T> other && Equals(other);
+
+    /// <summary>
+    /// Returns the hash code for this result.
+    /// </summary>
+    /// <returns>A hash code for this result.</returns>
+    public override int GetHashCode() => HashCode.Combine(IsSuccess, _value, _error);
+
+    /// <summary>
+    /// Determines whether two results are equal.
+    /// </summary>
+    /// <param name="left">The left result.</param>
+    /// <param name="right">The right result.</param>
+    /// <returns><see langword="true"/> when the results are equal; otherwise, <see langword="false"/>.</returns>
+    public static bool operator ==(Result<T> left, Result<T> right) => left.Equals(right);
+
+    /// <summary>
+    /// Determines whether two results are not equal.
+    /// </summary>
+    /// <param name="left">The left result.</param>
+    /// <param name="right">The right result.</param>
+    /// <returns><see langword="true"/> when the results differ; otherwise, <see langword="false"/>.</returns>
+    public static bool operator !=(Result<T> left, Result<T> right) => !left.Equals(right);
+}


### PR DESCRIPTION
## Summary

Foundation types for the Result<T> pattern adoption across the MoreSpeakers codebase.

This change introduces:
- **Result<T>**: Generic success/failure wrapper for expected failures
- **Result**: Non-generic variant for void operations
- **Error**: Structured error representation with context (code, message, details)

These types establish the foundation for Phase 1 of the exception handling standardization initiative (#385–#394), enabling typed, explicit error handling across all vertical slices.

Closes #385