### PR TITLE
test: sync xUnit versions across all test projects

### DIFF
--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -13,9 +13,16 @@
 
 - 2026-04-13: Team initialized with the Alien cast.
 - 2026-04-15: Issue #386 Expertise Result<T> web surface completed. Admin Expertise pages use inline `ModelState` for same-page errors and `TempData["ErrorMessage"]` for redirects. HTMX new-expertise in Register/Profile now render `Model.NewExpertiseResponse` to preserve server-rendered failure feedback. Fixed partial re-render bug that dropped validation errors. Speakers filters and homepage popular-expertise updated for Result surface. All web tests pass (48/48). Orchestration log archived. Web Result patterns now established for downstream verticals.
+- 2026-05-22: **Security milestone complete.** Issue #391 (PR #400): Fixed XSS via Html.Raw in `_ProfileEditForm.cshtml` and `_PasswordChangeForm.cshtml`. Issue #392 (PR #401): Fixed XSS via innerHTML in `expertise.js`, `register.js`, `name-validation-input.js`, `passkeys.js`, `file-upload.js`. Pattern: All server data rendered via createElement+textContent; static innerHTML annotated. Both PRs independent, no blockers. Decisions codified in squad ledger.
 
 ## Learnings
 
+- Issue #392 (2026-04-15): For icon+text messages injected from server responses, the safe pattern is: create the `<i>` element with `document.createElement`, set its className, clear the container with `textContent = ''`, then append the icon and a `document.createTextNode(message)`. Never interpolate server data into innerHTML.
+- Static-only innerHTML (spinners, loading indicators, page headers with no server data) should be annotated `// Safe: static string, no user data` rather than refactored, to signal intentional review.
+- `file-upload.js` file preview used `file.name` (client filesystem name) inside a template literal — still needs `textContent` since user-controlled input should never be injected via innerHTML.
+- `passkeys.js` `err.message` comes from caught JavaScript errors which can be influenced by server responses; always treat as untrusted and use `textContent`.
+
+- Issue #391 (2026-04-15): Fixed XSS via Html.Raw in profile partials. Three `@Html.Raw(...)` calls in `_ProfileEditForm.cshtml` (lines 7, 13) and `_PasswordChangeForm.cshtml` (line 6) replaced with plain `@Model.ValidationMessage` / `@Model.SuccessMessage`. Razor's default encoding is sufficient — static Bootstrap Icon markup (`<i class="bi bi-...">`) is hardcoded and safe.
 - The application UX is built with Razor Pages and HTMX, not a SPA.
 - Expertise admin pages should send redirect failures through `TempData["ErrorMessage"]` so the shared admin toast layout can render feedback after redirects.
 - The Register/Profile new-expertise HTMX partials must reuse `Model.NewExpertiseResponse` or server-side failure messages disappear on re-render.

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -13,6 +13,7 @@
 
 - 2026-04-13: Team initialized with the Alien cast.
 - 2026-04-13: Completed codebase quality review (security, code quality, testability, exception handling). Findings awaiting squad consensus.
+- 2026-05-22: **Security milestone complete (2026-05-22T17:43:10Z).** Bishop shipped PR #400 (Html.Raw XSS fixes in Razor profile partials) and PR #401 (innerHTML XSS fixes in 6 JS files). Decisions codified: Never use Html.Raw for user messages; all server data in JS must use createElement+textContent. Learnings: icon markup is safe when hardcoded; err.message and file.name are untrusted; static innerHTML should be annotated, not refactored. Orchestration logs archived. Both issues independent with no blockers encountered. Next phase: CI foundation (#383, #384, #393).
 
 ## Learnings
 

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -11,16 +11,21 @@
 
 ### Security: XSS via Html.Raw and JavaScript innerHTML
 
-**Status:** Proposed | **Severity:** Critical | **Owner:** api-agent
+**Status:** Applied (2026-05-22) | **Severity:** Critical | **Owner:** Bishop
 
-Three Razor partials render validation messages unsafely:
-- `Pages/Profile/_ProfileEditForm.cshtml` (lines 7, 13)
-- `Pages/Profile/_PasswordChangeForm.cshtml` (line 6)
+**Html.Raw Fix (PR #400):**
+- `Pages/Profile/_ProfileEditForm.cshtml` (lines 7, 13) — replaced Html.Raw with safe @Model expressions
+- `Pages/Profile/_PasswordChangeForm.cshtml` (line 6) — replaced Html.Raw with safe @Model expression
+- Decision: Never use Html.Raw for user-facing messages. Razor's default encoding is sufficient.
 
-Multiple JS files use `innerHTML` with server responses:
-- `register.js`, `expertise.js`, `name-validation-input.js`, `passkeys.js`
-
-**Fix:** Replace Html.Raw with safe Razor encoding. Use textContent or DOM creation in JS.
+**innerHTML Fix (PR #401):**
+- `expertise.js` — createElement+textContent for jsonData.message
+- `register.js` — createElement+textContent for response.message + updatePageHeader refactor
+- `name-validation-input.js` — createElement+textContent for server name matches
+- `passkeys.js` — createElement+textContent for err.message
+- `file-upload.js` — Explicit DOM creation; file.name via textContent
+- Static innerHTML in `register.js`, `site.js`, `name-validation-input.js` annotated: `// Safe: static string, no user data`
+- Decision: All server-controlled data in JS must use textContent or createElement, never innerHTML interpolation.
 
 ### Exception Handling: Adopt Result<T> Pattern (2025-07-18)
 
@@ -128,6 +133,12 @@ MoreSpeakers.Data.Tests had zero executable tests until xUnit runner was added. 
 **Status:** Active | **Owner:** Squad  
 **What:** For issue work, use git branches named as `issue-number-brief-description`.  
 **Why:** User request — improves traceability and branch hygiene.
+
+### User Directive: PR Review Context Preservation
+
+**Status:** Active | **Owner:** Squad  
+**What:** Put PR review findings in PR comments so review context is not lost.  
+**Why:** User request (2026-04-15T19:36:39Z via Copilot) — captured for team memory.
 
 ## Governance
 

--- a/src/MoreSpeakers.Data.Tests/MoreSpeakers.Data.Tests.csproj
+++ b/src/MoreSpeakers.Data.Tests/MoreSpeakers.Data.Tests.csproj
@@ -17,6 +17,7 @@
     </PackageReference>
     <PackageReference Include="xunit.v3" Version="3.2.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/src/MoreSpeakers.Managers.Tests/MoreSpeakers.Managers.Tests.csproj
+++ b/src/MoreSpeakers.Managers.Tests/MoreSpeakers.Managers.Tests.csproj
@@ -6,6 +6,7 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
+        <OutputType>Exe</OutputType>
         <AssemblyName>MoreSpeakers.Managers.Tests</AssemblyName>
         <Company>Woodruff Solutions, LLC</Company>
         <Authors>Chris Woodruff, Joseph Guadagno</Authors>
@@ -32,7 +33,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
-        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.v3" Version="3.2.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Fixes #384

## Changes

- Upgraded MoreSpeakers.Managers.Tests from xUnit v2 (2.9.3) to xUnit v3 (3.2.1)
- Added FluentAssertions to MoreSpeakers.Data.Tests for consistency with other test projects
- Added OutputType=Exe to Managers.Tests for xUnit v3 compatibility

## Testing

- All 262 tests pass across all test projects
- Build succeeds with no errors

## Standardized Versions

All test projects now use:
- xUnit.v3: 3.2.1
- xunit.runner.visualstudio: 3.1.5
- Microsoft.NET.Test.Sdk: 18.0.1
- FluentAssertions: 8.8.0 (where applicable)
- Moq: 4.20.72 (where applicable)