### PR TITLE
feat: convert Mentoring vertical to Result<T> (#388)

### DIFF
--- a/src/MoreSpeakers.Data/MentoringDataStore.cs
+++ b/src/MoreSpeakers.Data/MentoringDataStore.cs
@@ -483,6 +483,9 @@ public partial class MentoringDataStore : IMentoringDataStore
         return Result.Success(_mapper.Map<Mentorship>(mentorship));
     }
 
-    private static Result<T> Failure<T>(string code, string message) => Result.Failure<T>(new Error(code, message));
-    private static Result Failure(string code, string message) => Result.Failure(new Error(code, message));
+    private static Result<T> Failure<T>(string code, string message, Exception? exception = null) =>
+        Result.Failure<T>(new Error(code, message, exception));
+
+    private static Result Failure(string code, string message, Exception? exception = null) =>
+        Result.Failure(new Error(code, message, exception));
 }


### PR DESCRIPTION
## Summary

Converts the Mentoring vertical slice to use Result<T> and Result for explicit error handling, following the established pattern from Issue #386 (Expertise PoC).

## Changes

### Data Layer (MentoringDataStore.cs)
- Converted all methods to return Result<T> or Result
- Replaced sentinel 
ull/alse returns with explicit Result.Failure containing structured Error codes
- Added Failure helper methods for clean error creation
- Catch **only** DbUpdateException for expected persistence failures; broader exceptions bubble naturally
- Error codes follow kebab-case convention: mentoring.<operation>.<reason> (e.g., mentoring.not-found, mentoring.respond.failed)

### Manager Layer (MentoringManager.cs)
- Converted all methods to return Result<T> or Result
- Forwards DataStore Result values directly (no swallowing failures)
- Telemetry tracking only when operations succeed

### Interfaces
- IMentoringDataStore: Updated all method signatures to return Result<T> or Result
- IMentoringManager: Updated all method signatures to return Result<T> or Result

### Tests (MentoringDataStoreTests.cs)
- Created comprehensive test coverage for DataStore success/failure paths
- Uses DataStoreTestBase and ResultTestExtensions (ShouldSucceed, ShouldFail)
- Tests key scenarios: GetAsync, SaveAsync, DeleteAsync, GetSharedExpertisesAsync, RespondToRequestAsync, GetMentorAsync, CanRequestMentorshipAsync

## Build Status

✅ Domain project builds cleanly
✅ Managers project builds cleanly

Note: Data project shows expected errors from other verticals (UserDataStore is being converted in Issue #387). These errors will resolve once all verticals are merged.

## Resolves

Closes #388

## Next Steps

After this PR merges, the next vertical slices (#387 User, #389 Sector+SocialMediaSite) can proceed independently, followed by cross-cutting cleanup (#390).